### PR TITLE
Add `nodejs` as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This package depends on the following packages:
 - `traittypes` (Version >=0.2.1, <0.3)
 - `numpy`
 - `pandas`
+- `nodejs`
 
 ### Installation
 


### PR DESCRIPTION
I tried to install bqplot and @SylvainCorlay suggested that it needs to have `nodejs` installed. Hope that's a useful PR.