### PR TITLE
Move attributes from model to mark

### DIFF
--- a/js/src/Mark.ts
+++ b/js/src/Mark.ts
@@ -30,6 +30,8 @@ function is_defined(value){
 export abstract class Mark extends widgets.WidgetView {
 
     initialize () {
+        this.display_el_classes = ["mark"]; //classes on the element which
+        //trigger the tooltip to be displayed when they are hovered over
         this.setElement(document.createElementNS(d3.namespaces.svg, "g"));
         this.d3el = d3.select(this.el);
         super.initialize.apply(this, arguments);

--- a/js/src/MarkModel.ts
+++ b/js/src/MarkModel.ts
@@ -57,8 +57,6 @@ export class MarkModel extends BaseModel {
         // certain functions of views on that model might check the value
         // of `this.dirty` before rendering
         this.dirty = false;
-        this.display_el_classes = ["mark"]; //classes on the element which
-        //trigger the tooltip to be displayed when they are hovered over
         this.update_scales();
     }
 
@@ -127,7 +125,6 @@ export class MarkModel extends BaseModel {
     };
 
     dirty: boolean;
-    display_el_classes: Array<string>; 
     mark_data: any;
 
 }

--- a/js/src/OHLC.ts
+++ b/js/src/OHLC.ts
@@ -22,6 +22,7 @@ import { OHLCModel } from './OHLCModel';
 export class OHLC extends Mark {
 
     render() {
+        this.display_el_classes = ["stick_body"] ;
         const base_creation_promise = super.render();
 
         const that = this;

--- a/js/src/OHLCModel.ts
+++ b/js/src/OHLCModel.ts
@@ -46,7 +46,6 @@ export class OHLCModel extends MarkModel {
         this.on("change:format", this.update_format, this);
         this.px = { o: -1, h: -1, l: -1, c: -1 };
         this.mark_data = [];
-        this.display_el_classes = ["stick_body"] ;
         this.update_data();
         this.update_domains();
         this.update_format();


### PR DESCRIPTION
Some attributes are wrongly defined on the MarkModel instead of Mark. They've been this way for a while, but as they don't break anything they weren't caught.