### PR TITLE
Revert #786

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -1451,10 +1451,6 @@ class GridHeatMap(Mark):
     anchor_style: dict (default: {'fill': 'white', 'stroke': 'blue'})
         Controls the style for the element which serves as the anchor during
         selection.
-    display_format: string (default: None)
-        format for displaying values. If None, then values are not displayed
-    font_style: dict
-        CSS style for the text of each cell
 
     Data Attributes
 
@@ -1508,10 +1504,6 @@ class GridHeatMap(Mark):
     stroke = Color('black', allow_none=True).tag(sync=True)
     opacity = Float(1.0, min=0.2, max=1).tag(sync=True, display_name='Opacity')
     anchor_style = Dict({'fill': 'white', 'stroke': 'blue'}).tag(sync=True)
-
-    display_format = Unicode(default_value=None, allow_none=True)\
-        .tag(sync=True)
-    font_style = Dict().tag(sync=True)
 
     def __init__(self, **kwargs):
         data = kwargs['color']

--- a/examples/Marks/Object Model/GridHeatMap.ipynb
+++ b/examples/Marks/Object Model/GridHeatMap.ipynb
@@ -3,11 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
@@ -17,10 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Get Data"
    ]
@@ -28,11 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "np.random.seed(0)\n",
@@ -41,10 +30,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Basic Heat map"
    ]
@@ -52,50 +38,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "col_sc = ColorScale()\n",
     "grid_map = GridHeatMap(color=data, scales={'color': col_sc})\n",
+    "\n",
     "Figure(marks=[grid_map], padding_y=0.0)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "grid_map.display_format = '.2f'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "grid_map.font_style={'font-size': '12px', 'fill':'black', 'font-weight': 'bold'}"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Heat map with axes"
    ]
@@ -103,11 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x_sc, y_sc, col_sc = OrdinalScale(), OrdinalScale(reverse=True), ColorScale()\n",
@@ -120,10 +70,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Non Uniform Heat map"
    ]
@@ -131,11 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x_sc, y_sc, col_sc = LinearScale(), LinearScale(reverse=True), ColorScale()\n",
@@ -158,9 +101,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": true
    },
    "outputs": [],
@@ -172,20 +112,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Alignment of the data with respect to the grid"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "For a `N-by-N` matrix, `N+1` points along the row or the column are assumed to be end points."
    ]
@@ -193,11 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x_sc, y_sc, col_sc = LinearScale(), LinearScale(reverse=True), ColorScale()\n",
@@ -214,10 +144,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "By default, for `N` points along any dimension, data aligns to the `start` of the rectangles in the grid. \n",
     "The grid extends infinitely in the other direction. By default, the grid extends infintely\n",
@@ -227,11 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x_sc, y_sc, col_sc = LinearScale(), LinearScale(reverse=True, max=15), ColorScale()\n",
@@ -248,10 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "By changing the `row_align` and `column_align` properties, the grid can extend in the opposite direction"
    ]
@@ -259,11 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x_sc, y_sc, col_sc = LinearScale(), LinearScale(reverse=True, min=-5, max=15), ColorScale()\n",
@@ -281,10 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "For `N+1` points on any direction, the grid extends infintely in both directions"
    ]
@@ -292,11 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "x_sc, y_sc, col_sc = LinearScale(), LinearScale(reverse=True, min=-5, max=15), ColorScale()\n",
@@ -313,10 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Changing opacity and stroke"
    ]
@@ -324,11 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "col_sc = ColorScale()\n",
@@ -339,20 +241,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Selections on the grid map"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Selection on the `GridHeatMap` works similar to excel. Clicking on a cell selects the cell, and deselects the previous selection. Using the `Ctrl` key allows multiple cells to be selected, while the `Shift` key selects the range from the last cell in the selection to the current cell."
    ]
@@ -360,11 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "data = np.random.randn(10, 10)\n",
@@ -378,10 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The `selected` trait of a `GridHeatMap` contains a list of lists, with each sub-list containing the row and column index of a selected cell."
    ]
@@ -390,9 +279,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": false
    },
    "outputs": [],
@@ -404,9 +290,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": []
@@ -429,7 +313,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,

--- a/js/src/GridHeatMap.js
+++ b/js/src/GridHeatMap.js
@@ -136,8 +136,6 @@ var GridHeatMap = mark.Mark.extend({
         this.listenTo(this.parent, "bg_clicked", function() {
             this.event_dispatcher("parent_clicked");
         });
-        this.model.on_some_change(["display_format", "font_style"],
-                                  this.update_labels, this);
         this.listenTo(this.model, "change:selected", this.update_selected);
         this.listenTo(this.model, "change:interactions", this.process_interactions);
     },
@@ -452,45 +450,26 @@ var GridHeatMap = mark.Mark.extend({
             });
         });
 
-        this.display_cell_groups = this.display_rows.selectAll(".heatmapcell").data(function(d, i) {
+        this.display_cells = this.display_rows.selectAll(".heatmapcell").data(function(d, i) {
             return data_array[i];
-        })
-        .enter()
-        .append("g")
-        .attr("class", "heatmapcell")
-        .attr("transform", function(d, i) {
-            return "translate(" + column_plot_data.start[i] + ", 0)";
         });
-
-        this.display_cells = this.display_cell_groups
+        this.display_cells.enter()
             .append("rect")
-            .attr("class", "cell_rect")
+            .attr("class", "heatmapcell")
             .on("click", _.bind(function() {
                 this.event_dispatcher("element_clicked");
             }, this));
 
-        this.display_cell_groups
-            .append("text")
-            .attr("class", "cell_text")
-            .style({"text-anchor": "middle",
-                    "fill" : "black",
-                    "pointer-events": "none",
-                    "dominant-baseline": "central"});
-
-        this.display_cell_groups
-            .selectAll(".cell_rect")
-            .attr("x", 0)
-            .attr("y", 0)
+        this.display_cells
+            .attr({
+                "x": function(d, i) {
+                    return column_plot_data.start[i];
+                }, "y": 0
+            })
             .attr("width", function(d, i) { return column_plot_data.widths[i]; })
             .attr("height",function(d) { return row_plot_data.widths[d.row_num]; })
 
-        this.display_cell_groups
-            .selectAll(".cell_text")
-            .attr("x", function(d, i) { return column_plot_data.widths[i] / 2; })
-            .attr("y", function(d) { return row_plot_data.widths[d.row_num] / 2; });
-
         this.apply_styles();
-        this.update_labels();
 
         this.display_cells.on("click", function(d, i) {
             return that.event_dispatcher("element_clicked", {
@@ -508,15 +487,6 @@ var GridHeatMap = mark.Mark.extend({
 
     update_opacity: function(model, value) {
         this.display_cells.style("opacity", value);
-    },
-
-    update_labels: function() {
-        var display_format_str = this.model.get("display_format");
-        var display_format = d3.format(display_format_str);
-
-        d3.selectAll(".cell_text")
-            .text(function(d, i) { return display_format_str ? display_format(d.color) : null; })
-            .style(this.model.get("font_style"));
     },
 
     get_tile_plotting_data: function(scale, data, mode, start) {


### PR DESCRIPTION
In JupyterLab, it appears that #786 is causing a GridHeatMap to show a blank plot. It seems that possibly what is happening is that it can't calculate an accurate width, so the plot ends up being something like 5 pixels wide (it has a min width of 125px, and 60px*2 is subtracted off for margins, so the plot mark gets the remaining 5px, it seems).

For now, reverting this until we can figure out the root of the issue. Perhaps there is a race condition in measuring an accurate width?


```python
from __future__ import print_function
import numpy as np
from bqplot import *

np.random.seed(0)
data = np.random.randn(10, 10)

col_sc = ColorScale()
grid_map = GridHeatMap(color=data, scales={'color': col_sc})
Figure(marks=[grid_map], padding_y=0.0, min_aspect_ratio=0.01)
```
gives
![Screen Shot 2019-08-13 at 11 30 04 AM](https://user-images.githubusercontent.com/192614/62967432-c9958a00-bdbd-11e9-97f7-7dfa977acff3.png)

