### PR TITLE
fix: DateScale doesn't apply browser timezone for ticks anymore

### DIFF
--- a/js/src/Axis.ts
+++ b/js/src/Axis.ts
@@ -243,7 +243,7 @@ export class Axis extends WidgetView {
         if(this.axis_scale.model.type === "date" ||
            this.axis_scale.model.type === "date_color_linear") {
             if(this.model.get("tick_format")) {
-                return d3.timeFormat(this.model.get("tick_format"));
+                return d3.utcFormat(this.model.get("tick_format"));
             } else {
                 return this.guess_tick_format();
             }
@@ -254,7 +254,7 @@ export class Axis extends WidgetView {
                 //check the instance of the elements in the domain and
                 //apply the format depending on that.
                 if(utils.is_valid_time_format(tick_format)) {
-                    return d3.timeFormat(tick_format);
+                    return d3.utcFormat(tick_format);
                 } else {
                     return d3.format(tick_format);
                 }
@@ -796,65 +796,65 @@ export class Axis extends WidgetView {
         // diff is the difference between ticks in milliseconds
         const diff = Math.abs(ticks[1] - ticks[0]);
 
-        const format_millisecond = d3.timeFormat(".%L"),
-            format_second = d3.timeFormat(":%S"),
-            format_minute = d3.timeFormat("%I:%M"),
-            format_hour = d3.timeFormat("%I %p"),
-            format_day = d3.timeFormat("%b %d"),
-            format_month = d3.timeFormat("%b %Y"),
-            format_year = d3.timeFormat("%Y");
+        const format_millisecond = d3.utcFormat(".%L"),
+            format_second = d3.utcFormat(":%S"),
+            format_minute = d3.utcFormat("%I:%M"),
+            format_hour = d3.utcFormat("%I %p"),
+            format_day = d3.utcFormat("%b %d"),
+            format_month = d3.utcFormat("%b %Y"),
+            format_year = d3.utcFormat("%Y");
 
         return (date) => {
             let div = 1000;
             if(Math.floor(diff / div) === 0) {
                 //diff is less than a second
-                if(d3.timeSecond(date) < date) {
+                if(d3.utcSecond(date) < date) {
                     return format_millisecond(date);
-                } else if(d3.timeMinute(date) < date) {
+                } else if(d3.utcMinute(date) < date) {
                     return format_second(date);
                 } else {
                     return format_minute(date);
                 }
             } else if (Math.floor(diff / (div *= 60)) === 0) {
                 //diff is less than a minute
-                if(d3.timeMinute(date) < date) {
+                if(d3.utcMinute(date) < date) {
                     return format_second(date);
                 } else {
                     return format_minute(date);
                 }
             } else if (Math.floor(diff / (div *= 60)) === 0) {
                 // diff is less than an hour
-                if(d3.timeHour(date) < date) {
+                if(d3.utcHour(date) < date) {
                     return format_minute(date);
                 } else {
                     return format_hour(date);
                 }
             } else if (Math.floor(diff / (div *= 24)) === 0) {
                 //diff is less than a day
-                if(d3.timeDay(date) < date) {
+                if(d3.utcDay(date) < date) {
                     return format_hour(date);
                 } else {
                     return format_day(date);
                 }
             } else if (Math.floor(diff / (div *= 27)) === 0) {
                 //diff is less than a month
-                if(d3.timeMonth(date) < date) {
+                if(d3.utcMonth(date) < date) {
                     return format_day(date);
                 } else {
                     return format_month(date);
                 }
             } else if (Math.floor(diff / (div *= 12)) === 0) {
                 //diff is less than a year
-                if(d3.timeMonth(date) < date) {
+                if(d3.utcMonth(date) < date) {
                     return format_day(date);
                 } else {
                     return format_month(date);
                 }
             } else {
                 //diff is more than a year
-                if(d3.timeMonth(date) < date) {
+                if(d3.utcMonth(date) < date) {
                     return format_day(date);
-                } else if (d3.timeYear(date) < date) {
+                } else if (d3.utcYear(date) < date) {
                     return format_month(date);
                 } else {
                     return format_year(date);

--- a/js/src/ColorAxis.ts
+++ b/js/src/ColorAxis.ts
@@ -99,7 +99,7 @@ class ColorBar extends Axis {
             that.axis_scale = view;
             // TODO: eventually removes what follows
             if(that.axis_scale.model.type === "date_color_linear") {
-                that.axis_line_scale = d3.scaleTime().nice();
+                that.axis_line_scale = d3.scaleUtc().nice();
             } else if(that.axis_scale.model.type === "ordinal") {
                 that.axis_line_scale = d3.scaleBand();
                 that.ordinal = true;

--- a/js/src/DateColorScale.ts
+++ b/js/src/DateColorScale.ts
@@ -20,7 +20,7 @@ import { ColorScale } from './ColorScale';
 export class DateColorScale extends ColorScale {
 
     create_d3_scale() {
-        this.scale = d3.scaleTime();
+        this.scale = d3.scaleUtc();
     }
 }
 

--- a/js/src/DateScale.ts
+++ b/js/src/DateScale.ts
@@ -19,7 +19,7 @@ import { LinearScale } from './LinearScale';
 
 export class DateScale extends LinearScale {
     render() {
-        this.scale = d3.scaleTime();
+        this.scale = d3.scaleUtc();
         if(this.model.domain.length > 0)
             this.scale.domain(this.model.domain);
         this.offset = 0;


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #967 *

On the frontend dates are represented by timestamps (js native Date internally uses a timestamp). But, conversion of a mere date into a timestamp isn't really possible when it's not known in which timezone the date was recorded (2019-01-01 00:00 doesn't give enough information for conversion into a timestamp. 2019-01-01T00:00+02:00 does). As convention utc is used to generate a timestamp even though that timestamp will most likely not be the actual point in time when the date's event occurred. This is ok if the timestamp is converted back into a timezone-less date using utc.

In the frontend this conversion back was performed using the local timezone of the user's browser. The frontend uses javascript native conversion functions for dates (new Date(...)) and also d3's conversion functions (timeFormat, timeSecond, timeMinute, timeHour). Luckily, d3 caters for the case that timestamps are encoded using utc. The corresponding functions are utcFormat, utcSecond, utcMinute, utcHour.

**Testing performed**
I ran the tests in the "tests" directory:
=== 9 passed, 12 warnings in 0.10 seconds ===
I executed the example given in the bug and confirmed that the ticks now show the correct dates.