### PR TITLE
fix: no timezone jump on PanZoom actions

### DIFF
--- a/js/src/Axis.ts
+++ b/js/src/Axis.ts
@@ -678,7 +678,7 @@ export class Axis extends WidgetView {
             max = (scale_range[max_index] + (step * 0.5));
             const range_in_times = _.range(scale_range[0], max, step);
             return range_in_times.map((elem) => {
-                return new Date(elem);
+                return new Date(elem+"+00:00");
             });
         } else {
             max = (scale_range[max_index] + (step * 0.5));

--- a/js/src/BaseModel.ts
+++ b/js/src/BaseModel.ts
@@ -39,7 +39,7 @@ export class BaseModel extends WidgetModel {
         if(elem === undefined || elem === null) {
             return null;
         }
-        return new Date(elem);
+        return new Date(elem+"+00:00");
     }
 
     convert_to_json(elem) {


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #617 *

On a start pan and on every zoom action the date is converted to json and back. On the serialization utc is assumed for the date but the timezone information is not put onto the date string that is generated. On the deserialization `new Date` is invoked manually which makes the browser think the provided date is in the user's browser's timezone (because the json serialization didn't add timezone information). But the json serialization used utc.

Because the serialization uses a set format I just added the timezone information to the date string. This is not super elegant but seems to work. This issue and fix is strongly related to #968
Conversion of dates should maybe be more streamlined throughout the library and possibly use only the d3 conversion functions or maybe use Moment.js

This fix also fixes #865 and likely it fixes #767 

**Testing performed**
I ran the tests in the "tests" directory:
=== 9 passed, 12 warnings in 0.10 seconds ===
I executed my own minimal replicating example given in the bug and confirmed that the behavior is now as expected.
