### PR TITLE
Scatter: default_opacities -> opacities

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -522,7 +522,7 @@ class _ScatterBase(Mark):
         'opacity': {'dimension': 'opacity'},
         'rotation': {'dimension': 'rotation'}
     }).tag(sync=True)
-    default_opacities = Array([1.0])\
+    opacities = Array([1.0])\
         .tag(sync=True, display_name='Opacities', **array_serialization)\
         .valid(array_squeeze, array_dimension_bounds(1, 1))
     hovered_style = Dict().tag(sync=True)
@@ -592,7 +592,7 @@ class Scatter(_ScatterBase):
         Stroke color of the marker
     stroke_width: Float (default: 1.5)
         Stroke width of the marker
-    default_opacities: list of floats (default: [1.0])
+    opacities: list of floats (default: [1.0])
         Default opacities of the markers. If the list is shorter than
         the number
         of points, the opacities are reused.
@@ -694,6 +694,16 @@ class Scatter(_ScatterBase):
         warn("default_colors is deprecated, use colors instead.",
              DeprecationWarning)
         self.colors = value
+
+    @property
+    def default_opacities(self):
+        return self.opacities
+
+    @default_opacities.setter
+    def default_opacities(self, value):
+        warn("default_opacities is deprecated, use opacities instead.",
+             DeprecationWarning)
+        self.opacities = value
 
     stroke = Color(None, allow_none=True).tag(sync=True,
                                               display_name='Stroke color')

--- a/examples/Applications/Feature_Vector_Distribution-Iris-Digits.ipynb
+++ b/examples/Applications/Feature_Vector_Distribution-Iris-Digits.ipynb
@@ -134,7 +134,7 @@
     "                                y=group[1][feature2].values,\n",
     "                                names=names,\n",
     "                                display_names=False,\n",
-    "                                default_opacities=[0.5],\n",
+    "                                opacities=[0.5],\n",
     "                                default_size=30,\n",
     "                                scales={'x': sc_x, 'y': sc_y}, \n",
     "                                colors=[colors[index]],\n",
@@ -394,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.2"
   },
   "toc": {
    "nav_menu": {},

--- a/examples/Marks/Object Model/Scatter.ipynb
+++ b/examples/Marks/Object Model/Scatter.ipynb
@@ -120,7 +120,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatt.default_opacities = [0.3, 0.5, 1.]"
+    "scatt.opacities = [0.3, 0.5, 1.]"
    ]
   },
   {
@@ -343,7 +343,7 @@
    "outputs": [],
    "source": [
     "## Changing the opacity of the scatter\n",
-    "scatter2.default_opacities = [0.5, 0.3, 0.1]"
+    "scatter2.opacities = [0.5, 0.3, 0.1]"
    ]
   },
   {
@@ -363,7 +363,7 @@
    "outputs": [],
    "source": [
     "## Resetting the opacity and setting the opacity according to the date\n",
-    "scatter2.default_opacities = [1.0]"
+    "scatter2.opacities = [1.0]"
    ]
   },
   {
@@ -739,7 +739,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Object Model/ScatterMega.ipynb
+++ b/examples/Marks/Object Model/ScatterMega.ipynb
@@ -367,7 +367,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatt.default_opacities = [0.3, 0.5, 1.]"
+    "scatt.opacities = [0.3, 0.5, 1.]"
    ]
   },
   {
@@ -528,7 +528,7 @@
    "outputs": [],
    "source": [
     "## Changing the opacity of the scatter\n",
-    "scatter2.default_opacities = [0.5, 0.3, 0.1]"
+    "scatter2.opacities = [0.5, 0.3, 0.1]"
    ]
   },
   {
@@ -538,7 +538,7 @@
    "outputs": [],
    "source": [
     "## Resetting the opacity and setting the opacity according to the date\n",
-    "scatter2.default_opacities = [1.0]"
+    "scatter2.opacities = [1.0]"
    ]
   },
   {
@@ -612,7 +612,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/examples/Marks/Pyplot/Scatter.ipynb
+++ b/examples/Marks/Pyplot/Scatter.ipynb
@@ -112,7 +112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scatt.default_opacities = [0.3, 0.5, 1.]"
+    "scatt.opacities = [0.3, 0.5, 1.]"
    ]
   },
   {
@@ -315,7 +315,7 @@
    "outputs": [],
    "source": [
     "## Changing the opacity of the scatter\n",
-    "scatter2.default_opacities = [0.5, 0.3, 0.1]"
+    "scatter2.opacities = [0.5, 0.3, 0.1]"
    ]
   },
   {
@@ -335,7 +335,7 @@
    "outputs": [],
    "source": [
     "## Resetting the opacity and setting the opacity according to the date\n",
-    "scatter2.default_opacities = [1.0]"
+    "scatter2.opacities = [1.0]"
    ]
   },
   {
@@ -641,7 +641,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/js/src/Label.ts
+++ b/js/src/Label.ts
@@ -28,14 +28,14 @@ export class Label extends ScatterBase {
                                    "rotate_angle"], this.update_position, this);
     }
 
-    update_default_opacities(animate) {
+    update_opacities(animate) {
         if (!this.model.dirty) {
             const animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
             // update opacity scale range?
             const that = this;
             this.d3el.selectAll(".label")
-                .transition("update_default_opacities")
+                .transition("update_opacities")
                 .duration(animation_duration)
                 .style("opacity", function(d, i) {
                     return that.get_element_opacity(d, i);
@@ -69,7 +69,7 @@ export class Label extends ScatterBase {
 
         this.update_text();
         this.update_style();
-        this.update_default_opacities(true);
+        this.update_opacities(true);
     }
 
     update_text() {

--- a/js/src/Scatter.ts
+++ b/js/src/Scatter.ts
@@ -37,7 +37,7 @@ export class Scatter extends ScatterBase {
         this.listenTo(this.model, "change:colors", this.update_colors);
         this.listenTo(this.model, "change:stroke", this.update_stroke);
         this.listenTo(this.model, "change:stroke_width", this.update_stroke_width);
-        this.listenTo(this.model, "change:default_opacities", this.update_default_opacities);
+        this.listenTo(this.model, "change:opacities", this.update_opacities);
         this.listenTo(this.model, "change:default_skew", this.update_default_skew);
         this.listenTo(this.model, "change:marker", this.update_marker);
         this.listenTo(this.model, "change:default_size", this.update_default_size);
@@ -107,18 +107,18 @@ export class Scatter extends ScatterBase {
         }
     }
 
-    update_default_opacities(animate) {
+    update_opacities(animate) {
         if (!this.model.dirty) {
-            const default_opacities = this.model.get("default_opacities");
+            const opacities = this.model.get("opacities");
             const colors = this.model.get("colors");
             const len = colors.length;
-            const len_opac = default_opacities.length;
+            const len_opac = opacities.length;
             const animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
 
             // update opacity scale range?
             const that = this;
             this.d3el.selectAll(".dot")
-                .transition("update_default_opacities")
+                .transition("update_opacities")
                 .duration(animation_duration)
                 .style("opacity", function(d, i) {
                     return that.get_element_opacity(d, i);
@@ -126,7 +126,7 @@ export class Scatter extends ScatterBase {
             if (this.legend_el) {
                 this.legend_el.select("path")
                 .style("opacity", function(d, i) {
-                    return default_opacities[i % len_opac];
+                    return opacities[i % len_opac];
                 })
                 .style("fill", function(d, i) {
                     return colors[i % len];
@@ -264,7 +264,8 @@ export class Scatter extends ScatterBase {
             that = this;
         elements
           .style("fill", fill ? this.get_mark_color.bind(this) : "none")
-          .style("stroke", stroke ? stroke: this.get_mark_color.bind(this)).style("opacity", function(d, i) {
+          .style("stroke", stroke ? stroke: this.get_mark_color.bind(this))
+          .style("opacity", function(d, i) {
               return that.get_element_opacity(d, i);
           }).style("stroke-width", stroke_width);
     }

--- a/js/src/ScatterBase.ts
+++ b/js/src/ScatterBase.ts
@@ -156,7 +156,7 @@ export abstract class ScatterBase extends Mark {
         if (opacity_scale) {
             this.listenTo(opacity_scale, "domain_changed", () => {
                 const animate = true;
-                this.update_default_opacities(animate);
+                this.update_opacities(animate);
             });
         }
         if (skew_scale) {
@@ -212,12 +212,12 @@ export abstract class ScatterBase extends Mark {
 
     get_element_opacity(data, index) {
         const opacity_scale = this.scales.opacity;
-        const default_opacities = this.model.get("default_opacities");
-        const len = default_opacities.length;
+        const opacities = this.model.get("opacities");
+        const len = opacities.length;
         if(opacity_scale && data.opacity !== undefined) {
             return opacity_scale.scale(data.opacity);
         }
-        return default_opacities[index % len];
+        return opacities[index % len];
     }
 
     get_element_skew(data) {
@@ -680,7 +680,7 @@ export abstract class ScatterBase extends Mark {
     }
 
     abstract color_scale_updated(animate?);
-    abstract update_default_opacities(animate?);
+    abstract update_opacities(animate?);
     abstract update_default_skew(animate?);
     abstract update_default_size(animate?);
 

--- a/js/src/ScatterBaseModel.ts
+++ b/js/src/ScatterBaseModel.ts
@@ -41,7 +41,7 @@ export class ScatterBaseModel extends MarkModel {
         hovered_style: {},
         unhovered_style: {},
         colors: ['steelblue'],
-        default_opacities: [1.0],
+        opacities: [1.0],
         enable_move: false,
         enable_delete: false,
         restrict_x: false,
@@ -138,6 +138,6 @@ export class ScatterBaseModel extends MarkModel {
         opacity: serialize.array_or_json,
         size: serialize.array_or_json,
         rotation: serialize.array_or_json,
-        default_opacities: serialize.array_or_json
+        opacities: serialize.array_or_json
     }
 }

--- a/js/src/ScatterGL.ts
+++ b/js/src/ScatterGL.ts
@@ -319,9 +319,9 @@ export class ScatterGL extends Mark {
     }
 
     get_opacity_attribute_parameters() {
-        let default_opacities = this.model.get('default_opacities') || [1.];
+        let opacities = this.model.get('opacities') || [1.];
 
-        if (default_opacities.length == 0) default_opacities = [1.];
+        if (opacities.length == 0) opacities = [1.];
 
         if (this.model.get('opacity')) {
             const opacity = this.model.get('opacity');
@@ -333,7 +333,7 @@ export class ScatterGL extends Mark {
 
                 _.each(_.range(this.markers_number - opacity.length), (i) => {
                     i = i + opacity.length;
-                    array[i] = default_opacities[i % default_opacities.length];
+                    array[i] = opacities[i % opacities.length];
                 });
             }
             else {
@@ -344,14 +344,14 @@ export class ScatterGL extends Mark {
         } else {
             let array: Float32Array;
             let mesh_per_attribute: number;
-            if (default_opacities.length == 1) {
-                array = to_float_array(default_opacities);
+            if (opacities.length == 1) {
+                array = to_float_array(opacities);
                 mesh_per_attribute = this.markers_number;
             } else {
                 array = to_float_array(this.markers_number);
                 mesh_per_attribute = 1;
                 _.each(_.range(this.markers_number), (i) => {
-                    array[i] = default_opacities[i % default_opacities.length];
+                    array[i] = opacities[i % opacities.length];
                 });
             }
 
@@ -497,7 +497,7 @@ export class ScatterGL extends Mark {
         this.listenTo(this.model, "change:y", this.update_y);
 
         this.listenTo(this.model, "change:color change:colors change:unselected_style", this.update_color);
-        this.listenTo(this.model, "change:opacity change:default_opacities", this.update_opacity);
+        this.listenTo(this.model, "change:opacity change:opacities", this.update_opacity);
         this.listenTo(this.model, "change:size change:default_size", this.update_size);
         this.listenTo(this.model, "change:rotation", this.update_rotation);
         this.listenTo(this.model, "change:selected", this.update_selected);

--- a/js/src/ScatterGLModel.ts
+++ b/js/src/ScatterGLModel.ts
@@ -68,6 +68,6 @@ export class ScatterGLModel extends MarkModel {
         size: serialize.array_or_json,
         rotation: serialize.array_or_json,
         opacity: serialize.array_or_json,
-        default_opacities: serialize.array_or_json
+        opacities: serialize.array_or_json
     }
 };

--- a/js/src/test/scatter-mega.ts
+++ b/js/src/test/scatter-mega.ts
@@ -85,26 +85,26 @@ describe("scatter mega >", () => {
         const objects = await create_figure_scatter(this.manager, x, y, true);
         const scatter = objects.scatter;
 
-        const default_opacities = new Float32Array([1.]);
-        expect(scatter.opacity.array).to.deep.equal(default_opacities);
+        const opacities = new Float32Array([1.]);
+        expect(scatter.opacity.array).to.deep.equal(opacities);
         expect(scatter.opacity.meshPerAttribute).to.equal(3);
-        expect(scatter.opacity_previous.array).to.deep.equal(default_opacities);
+        expect(scatter.opacity_previous.array).to.deep.equal(opacities);
         expect(scatter.opacity_previous.meshPerAttribute).to.equal(3);
 
-        const default_opacities2 = new Float32Array([0.5]);
-        scatter.model.set('default_opacities', default_opacities2);
+        const opacities2 = new Float32Array([0.5]);
+        scatter.model.set('opacities', opacities2);
         expect(scatter.opacity.meshPerAttribute).to.equal(3);
-        expect(scatter.opacity.array).to.deep.equal(default_opacities2);
-        expect(scatter.opacity_previous.array).to.deep.equal(default_opacities);
+        expect(scatter.opacity.array).to.deep.equal(opacities2);
+        expect(scatter.opacity_previous.array).to.deep.equal(opacities);
         expect(scatter.opacity.meshPerAttribute).to.equal(3);
 
-        // We push an array of size 2 for the default_opacities. We have 3 markers
-        // so the default_opacities should be used periodicly
-        scatter.model.set('default_opacities', new Float32Array([0.5, 1.0]));
+        // We push an array of size 2 for the opacities. We have 3 markers
+        // so the opacities should be used periodicly
+        scatter.model.set('opacities', new Float32Array([0.5, 1.0]));
         expect(scatter.opacity.array).to.deep.equal(new Float32Array([0.5, 1.0, 0.5]));
         expect(scatter.opacity.meshPerAttribute).to.equal(1);
         expect(scatter.opacity_previous.meshPerAttribute).to.equal(3);
-        expect(scatter.opacity_previous.array).to.deep.equal(default_opacities2);
+        expect(scatter.opacity_previous.array).to.deep.equal(opacities2);
 
         const new_opacity = new Float32Array([0.5, 1.0, 0.8]);
         scatter.model.set('opacity', new_opacity);
@@ -113,7 +113,7 @@ describe("scatter mega >", () => {
         expect(scatter.opacity_previous.array).to.deep.equal(new Float32Array([0.5, 1.0, 0.5]))
         expect(scatter.opacity_previous.meshPerAttribute).to.equal(1);
 
-        // We push an array that is too short, default_opacities should be used
+        // We push an array that is too short, opacities should be used
         scatter.model.set('opacity', new Float32Array([0.8]));
         expect(scatter.opacity.array).to.deep.equal(new Float32Array([0.8, 1.0, 0.5]));
         expect(scatter.opacity.meshPerAttribute).to.equal(1);
@@ -227,7 +227,7 @@ describe("scatter mega >", () => {
 
         const steelblue = new Float32Array([0.27450981736183167, 0.5098039507865906, 0.7058823704719543]);
         const default_size = scatter.model.get('default_size');
-        const default_opacities = new Float32Array([1.]);
+        const opacities = new Float32Array([1.]);
 
         expect(scatter.markers_number).to.equal(2);
         expect(scatter.instanced_geometry.maxInstancedCount).to.equal(2);
@@ -236,7 +236,7 @@ describe("scatter mega >", () => {
         expect(scatter.size.array).to.deep.equal(new Float32Array([default_size]));
         expect(scatter.size.meshPerAttribute).to.equal(2);
 
-        expect(scatter.opacity.array).to.deep.equal(default_opacities);
+        expect(scatter.opacity.array).to.deep.equal(opacities);
         expect(scatter.opacity.meshPerAttribute).to.equal(2);
 
         expect(scatter.color.array).to.deep.equal(steelblue);
@@ -275,7 +275,7 @@ describe("scatter mega >", () => {
         expect(scatter.size.array).to.deep.equal(new Float32Array([default_size]));
         expect(scatter.size.meshPerAttribute).to.equal(3);
 
-        expect(scatter.opacity.array).to.deep.equal(default_opacities);
+        expect(scatter.opacity.array).to.deep.equal(opacities);
         expect(scatter.opacity.meshPerAttribute).to.equal(3);
 
         expect(scatter.color.array).to.deep.equal(steelblue);
@@ -297,7 +297,7 @@ describe("scatter mega >", () => {
 
         const steelblue = new Float32Array([0.27450981736183167, 0.5098039507865906, 0.7058823704719543]);
         const default_size = scatter.model.get('default_size');
-        const default_opacities = new Float32Array([1.]);
+        const opacities = new Float32Array([1.]);
 
         expect(scatter.markers_number).to.equal(2);
         expect(scatter.instanced_geometry.maxInstancedCount).to.equal(2);
@@ -306,7 +306,7 @@ describe("scatter mega >", () => {
         expect(scatter.size.array).to.deep.equal(new Float32Array([default_size]));
         expect(scatter.size.meshPerAttribute).to.equal(2);
 
-        expect(scatter.opacity.array).to.deep.equal(default_opacities);
+        expect(scatter.opacity.array).to.deep.equal(opacities);
         expect(scatter.opacity.meshPerAttribute).to.equal(2);
 
         expect(scatter.color.array).to.deep.equal(steelblue);
@@ -335,7 +335,7 @@ describe("scatter mega >", () => {
         expect(scatter.size.array).to.deep.equal(new Float32Array([default_size]));
         expect(scatter.size.meshPerAttribute).to.equal(2);
 
-        expect(scatter.opacity.array).to.deep.equal(default_opacities);
+        expect(scatter.opacity.array).to.deep.equal(opacities);
         expect(scatter.opacity.meshPerAttribute).to.equal(2);
 
         expect(scatter.color.array).to.deep.equal(steelblue);


### PR DESCRIPTION
Deprecate Scatter's `default_opacities` in favor of `opacities` (`default_colors` was deprecated in favor of `colors` in bqplot `0.8.4`).

Other marks had `opacities` instead of `default_opacities`, so this will make bqplot's API more homogeneous.

This is the first of several PRs for making `Mark`'s implementation more general, by adding common marks logic inside of it. For this purpose we need to make marks APIs more homogeneous.