### PR TITLE
fix: brush DOM state was not always in sync with model

### DIFF
--- a/js/src/BrushSelector.ts
+++ b/js/src/BrushSelector.ts
@@ -218,26 +218,24 @@ abstract class BrushMixinXSelector extends selector.BaseXSelector {
 
 export class BrushSelector extends BrushMixinXYSelector {
 
-    render() {
-        super.render.apply(this);
+    async render() {
+        await super.render();
         this.brush_render();
 
-        const that = this;
-        const scale_creation_promise = this.create_scales();
-        Promise.all([this.mark_views_promise, scale_creation_promise]).then(function() {
-            that.brush = d3.brush()
-              .on("start", _.bind(that.brush_start, that))
-              .on("brush", _.bind(that.brush_move, that))
-              .on("end", _.bind(that.brush_end, that));
-            that.brush.extent([[0, 0], [that.width, that.height]]);
+        await this.create_scales();
+        await this.mark_views_promise
+        this.brush = d3.brush()
+            .on("start", _.bind(this.brush_start, this))
+            .on("brush", _.bind(this.brush_move, this))
+            .on("end", _.bind(this.brush_end, this));
+        this.brush.extent([[0, 0], [this.width, this.height]]);
 
-            that.d3el.attr("class", "selector brushintsel");
-            that.brushsel = that.d3el.call(that.brush);
-            that.adjust_rectangle();
-            that.color_change();
-            that.create_listeners();
-            that.selected_changed();
-        });
+        this.d3el.attr("class", "selector brushintsel");
+        this.brushsel = this.d3el.call(this.brush);
+        this.adjust_rectangle();
+        this.color_change();
+        this.create_listeners();
+        this.selected_changed();
     }
 
     create_listeners() {
@@ -305,6 +303,7 @@ export class BrushSelector extends BrushMixinXYSelector {
                 function(a, b) { return a - b; });
             this.update_mark_selected(pixel_extent_x, pixel_extent_y);
         }
+        this.syncModelToBrush();
     }
 
     relayout() {
@@ -317,6 +316,10 @@ export class BrushSelector extends BrushMixinXYSelector {
         this.set_y_range([this.y_scale]);
 
         this.brush.extent([[0, 0], [this.width, this.height]]);
+        this.syncModelToBrush();
+    }
+
+    private syncModelToBrush() {
         if(this.model.get("selected_x") && this.model.get("selected_y")) {
             const range_x = this.model.get("selected_x").map(this.x_scale.scale).sort(
                 function(a, b) { return a - b; });

--- a/js/src/BrushSelector.ts
+++ b/js/src/BrushSelector.ts
@@ -326,7 +326,6 @@ export class BrushSelector extends BrushMixinXYSelector {
             const range_y = this.model.get("selected_y").map(this.y_scale.scale).sort(
                 function(a, b) { return a - b; });
             this.brush.move(this.d3el, [[range_x[0], range_y[0]], [range_x[1], range_y[1]]]);
-            this.brushsel = this.d3el.call(this.brush);
         }
     }
 

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -892,7 +892,7 @@ class Figure extends widgets.DOMWidgetView {
         });
     }
 
-    get_rendered_canvas(scale) {
+    get_rendered_canvas(scale) : Promise<HTMLCanvasElement> {
         // scale up the underlying canvas for high dpi screens
         // such that image is of the same quality
         scale = scale || window.devicePixelRatio;
@@ -939,6 +939,14 @@ class Figure extends widgets.DOMWidgetView {
             document.body.removeChild(a);
         });
     }
+
+    async getPixel(x, y) {
+        const canvas = await this.get_rendered_canvas(window.devicePixelRatio);
+        const context = canvas.getContext("2d");
+        const pixel = context.getImageData(x*window.devicePixelRatio, y*window.devicePixelRatio, 1, 1);
+        return pixel.data;
+    }
+
 
     update_gl() {
         if(!this._update_requested) {

--- a/js/src/test/interacts.ts
+++ b/js/src/test/interacts.ts
@@ -10,6 +10,7 @@ import * as d3Timer from 'd3-timer';
 const test_x = 200;
 const test_y = 250;
 const pixel_red = [255, 0, 0, 255];
+const pixel_green = [0, 255, 0, 255];
 const pixel_background = [255, 255, 255, 255];
 
 describe("interacts >", () => {
@@ -24,20 +25,42 @@ describe("interacts >", () => {
 
         let brush_selector = await create_model_bqplot(this.manager, 'BrushSelector', 'brush_selector_1', {
             'x_scale': figure.model.get('scale_x').toJSON(), 'y_scale': figure.model.get('scale_y').toJSON(),
-            'marks': [scatter.model.toJSON()]
+            'marks': [scatter.model.toJSON()],
+            'color': '#0f0' // green
         });
-        let brush_selector_view = await figure.set_interaction(brush_selector);
-        await brush_selector_view.displayed;
-        // all the events in figure are async, and we don't have access
-        // to the promises, so we manually call these methods
-        await brush_selector_view.create_scales()
-        await brush_selector_view.mark_views_promise;
-        brush_selector_view.relayout()
         brush_selector.set('selected_x', [0.5, 1.5])
         brush_selector.set('selected_y', [2.5, 3.5])
+        let brush_selector_view = await figure.set_interaction(brush_selector);
         let indices = scatter.model.get('selected')
         expect([...indices]).to.deep.equal([1]);
         expect(indices).to.be.an.instanceof(Uint32Array)
+
+        brush_selector_view.d3el.select(".selection").attr('fill-opacity', 1.0) // make sure it's full green
+        let brushColorData = await figure.getPixel(390, 10); // upper right corner
+        expect([...brushColorData]).to.deep.equals(pixel_green);
+
+        // removing the selector should not deselect
+        figure.set_interaction(null);
+        expect([...scatter.model.get('selected')]).to.deep.equal([1]);
+        // changing a disconnected brush, should not change the selection
+        brush_selector.set('selected_x', [-0.5, 0.5])
+        brush_selector.set('selected_y', [1.5, 2.5])
+        expect([...scatter.model.get('selected')]).to.deep.equal([1]);
+
+        // we restore the brush
+        brush_selector_view = await figure.set_interaction(brush_selector);
+        brush_selector_view.d3el.select(".selection").attr('fill-opacity', 1.0) // make sure it's full green
+        // and the selection should be updated
+        expect([...scatter.model.get('selected')]).to.deep.equal([0]);
+        brushColorData = await figure.getPixel(10, 490); // lower left corner
+        expect([...brushColorData]).to.deep.equals(pixel_green);
+
+        // we set the initial selection, and it should update the selection AND the DOM
+        brush_selector.set('selected_x', [0.5, 1.5])
+        brush_selector.set('selected_y', [2.5, 3.5])
+        expect([...scatter.model.get('selected')]).to.deep.equal([1]);
+        brushColorData = await figure.getPixel(390, 10); // upper right corner
+        expect([...brushColorData]).to.deep.equals(pixel_green);
     });
 
     it("brush interval selector basics", async function() {


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #1067*

**Describe your changes**
BrushSelector.relayout was doing too much, a part is split off into the method `syncModelToBrush`, which is now called in render and in selected_changed (which is called when the selected_x/y properties change).

Also, render is made async, and modernized, so that it's only attached to the DOM after the scales are created. This also makes the unittests much cleaner.

**Testing performed**
Full unittestst included, which tests if the rectangle (green) is drawn (pixel color is tested).
