### PR TITLE
fix: Figure.debouncedRelayout could be undefined

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -36,6 +36,9 @@ export
 class Figure extends widgets.DOMWidgetView {
 
     initialize() {
+        this.debouncedRelayout = _.debounce(() => {
+            this.relayout();
+        }, 300);
         // Internet Explorer does not support classList for svg elements
         this.el.classList.add("bqplot");
         this.el.classList.add("figure");
@@ -256,9 +259,6 @@ class Figure extends widgets.DOMWidgetView {
 
             // In the classic notebook, we should relayout the figure on
             // resize of the main window.
-            this.debouncedRelayout = _.debounce(() => {
-                this.relayout();
-            }, 300);
             window.addEventListener('resize', this.debouncedRelayout);
             this.once('remove', () => {
                 window.removeEventListener('resize', this.debouncedRelayout);


### PR DESCRIPTION
Depending on timing, Figure.debouncedRelayout was sometimes undefined, so we just have to assign this earlier.