### PR TITLE
Move attributes from model to mark

### DIFF
--- a/js/src/Mark.ts
+++ b/js/src/Mark.ts
@@ -39,6 +39,8 @@ function is_defined(value){
 export abstract class Mark extends widgets.WidgetView {
 
     initialize () {
+        this.display_el_classes = ["mark"]; //classes on the element which
+        //trigger the tooltip to be displayed when they are hovered over
         this.setElement(document.createElementNS(d3.namespaces.svg, "g"));
         this.d3el = d3.select(this.el);
         super.initialize.apply(this, arguments);

--- a/js/src/MarkModel.ts
+++ b/js/src/MarkModel.ts
@@ -56,8 +56,6 @@ export class MarkModel extends widgets.WidgetModel {
         // certain functions of views on that model might check the value
         // of `this.dirty` before rendering
         this.dirty = false;
-        this.display_el_classes = ["mark"]; //classes on the element which
-        //trigger the tooltip to be displayed when they are hovered over
         this.update_scales();
     }
 
@@ -126,7 +124,6 @@ export class MarkModel extends widgets.WidgetModel {
     };
 
     dirty: boolean;
-    display_el_classes: Array<string>;
     mark_data: any;
 
 }

--- a/js/src/OHLC.ts
+++ b/js/src/OHLC.ts
@@ -23,6 +23,7 @@ const d3GetEvent = function(){return require("d3-selection").event}.bind(this);
 export class OHLC extends Mark {
 
     render() {
+        this.display_el_classes = ["stick_body"] ;
         const base_creation_promise = super.render();
         this.selected_indices = this.model.get("selected");
         this.selected_style = this.model.get("selected_style");

--- a/js/src/OHLCModel.ts
+++ b/js/src/OHLCModel.ts
@@ -48,7 +48,6 @@ export class OHLCModel extends MarkModel {
         this.on("change:format", this.update_format, this);
         this.px = { o: -1, h: -1, l: -1, c: -1 };
         this.mark_data = [];
-        this.display_el_classes = ["stick_body"] ;
         this.update_data();
         this.update_domains();
         this.update_format();


### PR DESCRIPTION
I'd opened another PR which I have now closed:

The `display_el_classes` attribute is used by `Mark` to determine whether the mark responds to hit tests (see https://github.com/agoose77/bqplot/blob/cc37ac78cd80e6a91a66f615493c605ed3ae9feb/js/src/Mark.ts#L512). Before the TS port was performed, some of these attributes were erroneously defined on the Model *instead* of the Mark.