### PR TITLE
Add image pixelation control

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -1777,6 +1777,7 @@ class Image(Mark):
     _view_name = Unicode('Image').tag(sync=True)
     _model_name = Unicode('ImageModel').tag(sync=True)
     image = Instance(widgets.Image).tag(sync=True, **widget_serialization)
+    pixelated = Bool(True).tag(sync=True)
     x = Array(default_value=(0, 1)).tag(sync=True, scaled=True,
                                         rtype='Number',
                                         atype='bqplot.Axis',

--- a/js/less/bqplot.less
+++ b/js/less/bqplot.less
@@ -270,6 +270,16 @@
     .plotarea_events {
         opacity: 0; // fully transparent, only used for capturing events
     }
+    .image_pixelated {
+      /*
+      optimizespeed does not guarantee nearest neighbor, but firefox seems to do so for now
+      https://www.w3.org/TR/SVG/single-page.html#painting-ImageRenderingProperty
+      */
+      image-rendering: optimizespeed;
+      image-rendering: pixelated; /* chrome doesn't support optimizespeed */
+      image-rendering: -moz-crisp-edges; /* this is guaranteed to work for firefox */
+    }
+
 }
 .tooltip_div {
     z-index: 1001;

--- a/js/src/Image.ts
+++ b/js/src/Image.ts
@@ -29,7 +29,8 @@ export class Image extends Mark {
             .attr("y", 0)
             .attr("width", 1)
             .attr("height", 1)
-            .attr("preserveAspectRatio", "none");
+            .attr("preserveAspectRatio", "none")
+            .classed("image_pixelated", this.model.get('pixelated'));
         this.update_image();
 
         this.event_metadata = {
@@ -98,6 +99,9 @@ export class Image extends Mark {
             //animate on data update
             const animate = true;
             this.draw(animate);
+        });
+        this.listenTo(this.model, "change:pixelated", () => {
+            this.im.classed("image_pixelated", this.model.get('pixelated'));
         });
     }
 

--- a/js/src/ImageModel.ts
+++ b/js/src/ImageModel.ts
@@ -23,6 +23,7 @@ export class ImageModel extends MarkModel {
         return {...MarkModel.prototype.defaults(),
             _model_name: "ImageModel",
             _view_name: "Image",
+            pixelated: false,
             x: [0.0, 1.0],
             y: [0.0, 1.0],
             scales_metadata: {


### PR DESCRIPTION
I'd opened an old PR for this, which I've now closed.

This PR adds the ability to enable pixellation for an image. This is useful when using an Image display as a heatmap, as it is more performant than the builtin heatmap.