### PR TITLE
warn if scale.expand_domain is used but domain was empty

### DIFF
--- a/js/src/LinearScale.ts
+++ b/js/src/LinearScale.ts
@@ -39,7 +39,12 @@ export class LinearScale extends Scale {
         // To handle the case for a clamped scale for which we have to
         // expand the domain, the copy should be unclamped.
         unpadded_scale.clamp(false);
-        unpadded_scale.domain(this.model.domain);
+        if (this.model.domain.length) {
+            unpadded_scale.domain(this.model.domain);
+        } else {
+            // if the domain is empty, it will lead to NaN/NaN
+            console.error('No domain exists for scale, is that any data associated with this scale?')
+        }
         unpadded_scale.range(old_range);
         this.scale.domain(new_range.map(function(limit) {
             return unpadded_scale.invert(limit);


### PR DESCRIPTION
I was trying to debug #1085 which led me down a long rabbit hole, because the scale passed to the Scatter was not the same scale that was passed to the Interaction (a common error). This causes `model.domain` to be an empty list, causing this unpadded_scale to have a domain of NaN,NaN. This leads to weird behaviour, so I think the least we can do to detect this is to give a warning on the js console.