### PR TITLE
fix(Lines): set id properly on initial draw

### DIFF
--- a/js/src/Lines.ts
+++ b/js/src/Lines.ts
@@ -545,7 +545,7 @@ export class Lines extends Mark {
 
     draw(animate) {
         this.set_ranges();
-        const curves_sel = this.d3el.selectAll(".curve")
+        let curves_sel = this.d3el.selectAll(".curve")
           .data(this.model.mark_data);
 
         const y_scale = this.scales.y;
@@ -567,6 +567,7 @@ export class Lines extends Mark {
 
         const fill = this.model.get("fill"),
             area = (fill === "top" || fill === "bottom" || fill === "between");
+        curves_sel = this.d3el.selectAll(".curve");
         curves_sel.select(".line")
           .attr("id", function(d, i) { return "curve" + (i+1); })
           .on("click", _.bind(function() {


### PR DESCRIPTION
Follow up of #1114

On initial draw, a handdraw would still not redraw the line / set the y data.

The problem was that the curve id wasn't set. `curves_sel` is initially an empty d3 selection, and after we attached data and added the nodes, we should reassign to `curves_sel` it seems. I thought d3 would keep the DOM and its selection in sync, but apparently it does not, or something else is going on.

Some more background why it doesn't work: https://github.com/bqplot/bqplot/blob/f2f01a3df3b7238ea126363bc5f93c70d89d1a92/js/src/HandDraw.ts#L118 use the id to set the data.