### PR TITLE
Lines cleaning

### DIFF
--- a/js/src/Lines.ts
+++ b/js/src/Lines.ts
@@ -26,7 +26,6 @@ export class Lines extends Mark {
 
     render() {
         const base_render_promise = super.render();
-        const that = this;
         this.dot = bqSymbol().size(this.model.get("marker_size"));
         if (this.model.get("marker")) {
             this.dot.type(this.model.get("marker"));
@@ -36,18 +35,18 @@ export class Lines extends Mark {
         // because some of the functions depend on child scales being
         // created. Make sure none of the event handler functions make that
         // assumption.
-        this.displayed.then(function() {
-            that.parent.tooltip_div.node().appendChild(that.tooltip_div.node());
-            that.create_tooltip();
+        this.displayed.then(() => {
+            this.parent.tooltip_div.node().appendChild(this.tooltip_div.node());
+            this.create_tooltip();
         });
 
         this.display_el_classes = ["line", "legendtext", "dot"];
-        return base_render_promise.then(function() {
-            that.event_listeners = {};
-            that.process_interactions();
-            that.create_listeners();
-            that.compute_view_padding();
-            that.draw(false);
+        return base_render_promise.then(() => {
+            this.event_listeners = {};
+            this.process_interactions();
+            this.create_listeners();
+            this.compute_view_padding();
+            this.draw(false);
         });
     }
 

--- a/js/src/Lines.ts
+++ b/js/src/Lines.ts
@@ -184,12 +184,11 @@ export class Lines extends Mark {
         const that = this,
             fill = this.model.get("fill"),
             fill_color = this.model.get("fill_colors"),
-            opacities = this.model.get("opacities"),
             fill_opacities = this.model.get("fill_opacities");
         // update curve colors
         const curves = this.d3el.selectAll(".curve")
         curves.select(".line")
-          .style("opacity", function(d, i) { return opacities[i]; })
+          .style("opacity", this.get_mark_opacity.bind(this))
           .style("stroke", function(d, i) {
               return that.get_mark_color(d, i) || fill_color[i];
           })
@@ -209,7 +208,7 @@ export class Lines extends Mark {
               .style("stroke", function(d, i) {
                   return that.get_mark_color(d, i) || fill_color[i];
               })
-              .style("opacity", function(d, i) { return opacities[i]; })
+              .style("opacity", this.get_mark_opacity.bind(this))
               .style("fill", function(d, i) {
                   return that.model.get("fill") === "none" ?
                       "" : that.get_fill_color(d, i);
@@ -218,7 +217,7 @@ export class Lines extends Mark {
               .style("stroke", function(d, i) {
                   return that.get_mark_color(d, i) || fill_color[i];
               })
-              .style("opacity", function(d, i) { return opacities[i]; })
+              .style("opacity", this.get_mark_opacity.bind(this))
               .style("fill", function(d, i) {
                   return that.get_mark_color(d, i) || fill_color[i];
               });
@@ -226,9 +225,7 @@ export class Lines extends Mark {
               .style("fill", function(d, i) {
                   return that.get_mark_color(d, i) || fill_color[i];
               })
-              .style("opacity", function(d, i) {
-                  return opacities[i];
-              });
+              .style("opacity", this.get_mark_opacity.bind(this));
         }
         this.update_stroke_width(this.model, this.model.get("stroke_width"));
         this.update_line_style();
@@ -315,8 +312,7 @@ export class Lines extends Mark {
 
         const that = this,
             rect_dim = inter_y_disp * 0.8,
-            fill_colors = this.model.get("fill_colors"),
-            opacities = this.model.get("opacities");
+            fill_colors = this.model.get("fill_colors");
 
         this.legend_line = d3.line()
             .curve(this.get_interpolation())
@@ -354,7 +350,7 @@ export class Lines extends Mark {
                 return that.model.get("fill") === "none" ?
                     "" : that.get_fill_color(d, i);
             })
-            .style("opacity", function(d, i) { return opacities[i]; })
+            .style("opacity", this.get_mark_opacity.bind(this))
             .style("stroke-width", this.model.get("stroke_width"))
             .style("stroke-dasharray", _.bind(this.get_line_style, this));
 
@@ -375,7 +371,7 @@ export class Lines extends Mark {
             .style("fill", function(d, i) {
               return that.get_mark_color(d, i) || fill_colors[i];
             })
-            .style("opacity", function(d, i) { return opacities[i]; });
+            .style("opacity", this.get_mark_opacity.bind(this));
 
         this.legend_el = legend.merge(this.legend_el);
 


### PR DESCRIPTION
- turn `that` into `this`
- make use of the superclass's `get_mark_opacity` method