### PR TITLE
if we drop python2, we can use unittest.mock

### DIFF
--- a/test-environment.yml
+++ b/test-environment.yml
@@ -16,6 +16,5 @@ dependencies:
     - pytest  # test dependency
     - pytest-cov  # test dependency
     - selenium  # test dependency
-    - mock  # test dependency
     - flake8
     - nose

--- a/tests/selector_test.py
+++ b/tests/selector_test.py
@@ -1,5 +1,5 @@
 import bqplot
-from mock import Mock
+from unittest.mock import Mock
 import numpy as np
 from bqplot.traits import _array_equal
 


### PR DESCRIPTION
This requires us to first drop python2.7