### PR TITLE
Use round numbers for the figure size

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -81,6 +81,10 @@ class Figure extends widgets.DOMWidgetView {
             figureSize.width = figureSize.height * maxRatio;
         }
 
+        // Use round pixel values
+        figureSize.width = Math.floor(figureSize.width);
+        figureSize.height = Math.floor(figureSize.height);
+
         return figureSize;
     }
 


### PR DESCRIPTION
This has a side-effect to prevent useless relayout calls due to `getBoundingClientRect` precision issues. 

It improves performances in the case of having a plot in a tooltip: sometimes the clientrect width is evaluated to `334.023456 pixels`, sometimes `334.0235432535 pixels`, causing a useless relayout.