### PR TITLE
Improve bqplot classic theme

### DIFF
--- a/js/less/bqplot.less
+++ b/js/less/bqplot.less
@@ -111,10 +111,10 @@
 
 .classic {
     --bq-plotarea-background-fill: var(--jp-layout-color0);
-    --bq-axis-tick-text-fill: var(--jp-content-font-color0);
+    --bq-axis-tick-text-fill: var(--jp-content-font-color2);
 
-    --bq-grid-color: var(--jp-layout-color3);
-    --bq-axis-border-color: var(--jp-content-font-color1);
+    --bq-grid-color: var(--jp-layout-color2);
+    --bq-axis-border-color: var(--jp-content-font-color2);
     --bq-axis-path-stroke: var(--bq-axis-border-color);
     --bq-axis-rect-stroke: var(--bq-axis-border-color);
     --bq-axis-tick-stroke: var(--bq-grid-color);

--- a/js/less/bqplot.less
+++ b/js/less/bqplot.less
@@ -15,7 +15,6 @@
 
 :root {
     --bq-content-font-color: var(--jp-content-font-color1);
-    --bq-plotarea-background-fill: var(--jp-layout-color1);
     --bq-background: var(--jp-layout-color0);
     --bq-font: 12px sans-serif;
 
@@ -64,37 +63,62 @@
     --bq-network-node-element-fill: #666;
     --bq-network-node-label-text-shadow: 0 1px 0 #000, 1px 0 0 #000, 0 -1px 0 #000, -1px 0 0 #000;
     --bq-linkarrow-fill: #ccc;
-}
 
-/* Ideally this should be in :root */
-.common() {
-    --bq-axis-rect-stroke: var(--bq-tick-color);
-    --bq-axis-path-stroke: var(--bq-tick-color);
-    --bq-axis-tick-stroke: var(--bq-tick-color);
-    --bq-axis-tick-short-stroke: var(--bq-tick-color);
-
-    --bq-mainheading-fill: var(--bq-content-font-color);
-    --bq-axislabel-fill: var(--bq-content-font-color);
-
+    --bq-default-stroke: var(--bq-content-font-color);
     --bq-stick-stroke: var(--bq-content-font-color);
     --bq-stick-fill: var(--bq-content-font-color);
     --bq-sticktext-fill: var(--bq-content-font-color);
-    --bq-default-stroke: var(--bq-content-font-color);
+}
+
+/*
+ * gg and classic bqplot themes differ in the styling of the svg-background.
+ *
+ * plot area background fill: 
+ *   - gg: contrasted with the jupyterlab background. var(--jp-layout-color2);
+ *   - classic: less contrasted: var(--jp-layout-color1);
+ *
+ * tick text fill:
+ *   - gg: less contrasted with background: var(--jp-content-font-color2);
+ *   - classic: more contrasted with background: var(--jp-content-font-color1);
+ *
+ * grid, axes, and tick colors:
+ *   - gg: grid, axes, and tick marks are all of the same (grid) color
+ *   - classic: grid has little contrast with respect to the background while the axes,
+ *     and tick marks are more contrasted.
+ */
+
+.common() {
+    --bq-mainheading-fill: var(--bq-content-font-color);
+    --bq-axislabel-fill: var(--bq-content-font-color);
 }
 
 .gg {
-    --bq-axis-lines-color: var(--jp-layout-color1);
-    --bq-plotarea-background-fill: var(--jp-layout-color2);
-    --bq-tick-color: var(--bq-axis-lines-color);
+    --bq-plotarea-background-fill: var(--jp-layout-color1);
     --bq-axis-tick-text-fill: var(--jp-content-font-color2);
+
+    --bq-grid-color: var(--jp-layout-color0);
+    --bq-axis-rect-stroke: var(--bq-grid-color);
+    --bq-axis-path-stroke: var(--bq-grid-color);
+    --bq-axis-tick-stroke: var(--bq-grid-color);
+    --bq-axis-tick-short-stroke: var(--bq-grid-color);
 
     .common()
 }
 
+[data-jp-theme-light="true"] .gg {
+    --bq-plotarea-background-fill: var(--jp-layout-color2);
+}
+
 .classic {
-    --bq-axis-lines-color: var(--jp-ui-font-color3);
-    --bq-tick-color: var(--bq-axis-lines-color);
-    --bq-axis-tick-text-fill: var(--jp-ui-font-color2);
+    --bq-plotarea-background-fill: var(--jp-layout-color0);
+    --bq-axis-tick-text-fill: var(--jp-content-font-color0);
+
+    --bq-grid-color: var(--jp-layout-color3);
+    --bq-axis-border-color: var(--jp-content-font-color1);
+    --bq-axis-path-stroke: var(--bq-axis-border-color);
+    --bq-axis-rect-stroke: var(--bq-axis-border-color);
+    --bq-axis-tick-stroke: var(--bq-grid-color);
+    --bq-axis-tick-short-stroke: var(--bq-axis-border-color);
 
     .common()
 }


### PR DESCRIPTION
# Bqplot 0.11 had two different skins

A dark theme and a light theme.

The original light theme is similar to ggplot, with a light gray background and white gridlines.

![original-light](https://user-images.githubusercontent.com/2397974/82384169-93152b80-9a2f-11ea-870f-e1a8e1f76b6d.png)

The original dark theme is a more "classic" wireframe style.

![original-dark](https://user-images.githubusercontent.com/2397974/82384254-c22b9d00-9a2f-11ea-9fec-a3480d01859f.png)

# Bqplot 0.12 introduced the coloring based on JupyterLab colors

Since 0.12, bqplot makes use of the JupyterLab CSS variables for the coloring of the plot background to match the environment.

However, we kept two options for the bqplot styling: the "**gg**" style, similar to ggplot, and the "**classic**" style with the wireframe look. Roughly, "gg" looks like the original light theme in the with the JupyterLab light theme, and "classic" looks like the original dark theme in the JupyterLab dark theme

## 0.12 light "gg"

![old-gg-light](https://user-images.githubusercontent.com/2397974/82384640-90670600-9a30-11ea-91c6-ea4e006292ea.png)

## 0.12 light "classic"

![old-classic-light](https://user-images.githubusercontent.com/2397974/82384656-96f57d80-9a30-11ea-96f1-01c4378d3ca9.png)

## 0.12 dark "gg"

![old-gg-dark](https://user-images.githubusercontent.com/2397974/82384610-8513da80-9a30-11ea-9a34-67ae4c40871c.png)

## 0.12 dark "classic"

![old-classic-dark](https://user-images.githubusercontent.com/2397974/82384690-aaa0e400-9a30-11ea-8421-df366fba585f.png)

# In this PR

In this PR, I rework the colors to be closer to the original, especially in the dark theme. We still use JupyterLab variables.

## New light "gg"

![new-gg-light](https://user-images.githubusercontent.com/2397974/82384808-f8b5e780-9a30-11ea-8de2-3ba9a1d9e9a3.png)

## New light "classic"

![new-classic-light](https://user-images.githubusercontent.com/2397974/82384849-12efc580-9a31-11ea-80d6-ba169c8d6f65.png)

## New dark "gg"

![new-gg-dark](https://user-images.githubusercontent.com/2397974/82384861-184d1000-9a31-11ea-9d9a-c652381dec13.png)

## New dark "classic"

![new-classic-dark](https://user-images.githubusercontent.com/2397974/82384889-2438d200-9a31-11ea-976f-f2ff30bdc43b.png)

I think these changes improve the visual look of the dark theme, especially in the "gg" theme. In the classic mode, the axis lines are more highlighted and grid lines a bit less visible