### PR TITLE
Add opacity_mode attribute to the Bars class

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -973,6 +973,8 @@ class Bars(Mark):
         'element' means for every dimension of y, all bars have same color.
         'auto' picks 'group' and 'element' for 1-d and 2-d values of
         Y respectively.
+    opacity_mode: {'auto', 'group', 'element'}
+        Same as the `color_mode` attribute, but for the opacity.
     type: {'stacked', 'grouped'}
         whether 2-dimensional bar charts should appear grouped or stacked.
     colors: list of colors (default: ['steelblue'])
@@ -1060,6 +1062,8 @@ class Bars(Mark):
         'color': {'dimension': 'color'}
     }).tag(sync=True)
     color_mode = Enum(['auto', 'group', 'element'], default_value='auto')\
+        .tag(sync=True)
+    opacity_mode = Enum(['auto', 'group', 'element'], default_value='auto')\
         .tag(sync=True)
     type = Enum(['stacked', 'grouped'], default_value='stacked')\
         .tag(sync=True, display_name='Type')

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -966,14 +966,16 @@ class Bars(Mark):
         font-awesome icon for that mark
     name: string (class-level attribute)
         user-friendly name of the mark
-    color_mode: {'auto', 'group', 'element'}
-        enum attribute to specify if color should be the same for all bars with
-        the same x or for all bars which belong to the same array in Y
-        'group' means for every x all bars have same color.
-        'element' means for every dimension of y, all bars have same color.
-        'auto' picks 'group' and 'element' for 1-d and 2-d values of
-        Y respectively.
-    opacity_mode: {'auto', 'group', 'element'}
+    color_mode: {'auto', 'group', 'element', 'no_group'}
+        Specify how default colors are applied to bars.
+        The 'group' mode means colors are assigned per group. If the list
+        of colors is shorter than the number of groups, colors are reused.
+        The 'element' mode means colors are assigned per group element. If the list
+        of colors is shorter than the number of bars in a group, colors are reused.
+        The 'no_group' mode means colors are assigned per bar, discarding the fact
+        that there are groups or stacks. If the list of colors is shorter than the
+        total number of bars, colors are reused.
+    opacity_mode: {'auto', 'group', 'element', 'no_group'}
         Same as the `color_mode` attribute, but for the opacity.
     type: {'stacked', 'grouped'}
         whether 2-dimensional bar charts should appear grouped or stacked.
@@ -1061,9 +1063,9 @@ class Bars(Mark):
         'y': {'orientation': 'vertical', 'dimension': 'y'},
         'color': {'dimension': 'color'}
     }).tag(sync=True)
-    color_mode = Enum(['auto', 'group', 'element'], default_value='auto')\
+    color_mode = Enum(['auto', 'group', 'element', 'no_group'], default_value='auto')\
         .tag(sync=True)
-    opacity_mode = Enum(['auto', 'group', 'element'], default_value='auto')\
+    opacity_mode = Enum(['auto', 'group', 'element', 'no_group'], default_value='auto')\
         .tag(sync=True)
     type = Enum(['stacked', 'grouped'], default_value='stacked')\
         .tag(sync=True, display_name='Type')

--- a/examples/Marks/Object Model/Bars.ipynb
+++ b/examples/Marks/Object Model/Bars.ipynb
@@ -262,9 +262,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## Color mode has 2 values. 'group' and 'element'. \n",
-    "## 'group' means for every x all bars have same color.\n",
-    "## 'element' means for every dimension of y, all bars have same color.\n",
+    "## Color mode has 3 values. 'group', 'element' and 'no_group'. \n",
+    "## 'group' means colors are assigned per group.\n",
+    "## 'element' means colors are assigned per group element.\n",
+    "## 'no_group' means means colors are assigned per bar, discarding the fact that there are groups or stacks\n",
     "x_ord = OrdinalScale()\n",
     "y_sc = LinearScale()\n",
     "\n",
@@ -275,6 +276,24 @@
     "ax_y = Axis(scale=y_sc, orientation='vertical', tick_format='0.2f')\n",
     "\n",
     "Figure(marks=[bar], axes=[ax_x, ax_y])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bar.color_mode = 'element'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bar.color_mode = 'no_group'"
    ]
   },
   {
@@ -401,7 +420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,

--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -140,6 +140,7 @@ export class Bars extends Mark {
             this.draw(animate);
         });
         this.listenTo(this.model, "change:colors", this.update_colors);
+        this.listenTo(this.model, "change:opacities", this.update_colors);
         this.listenTo(this.model, "colors_updated", this.update_colors);
         this.listenTo(this.model, "change:type", this.update_type);
         // FIXME: These are expensive calls for changing padding and align
@@ -147,7 +148,7 @@ export class Bars extends Mark {
         this.listenTo(this.model, "change:padding", this.relayout)
         this.listenTo(this.model, "change:orientation", this.relayout)
         this.listenTo(this.model, "change:tooltip", this.create_tooltip);
-        this.model.on_some_change(['stroke', 'opacities', 'fill', 'stroke_width'], this.apply_styles, this);
+        this.model.on_some_change(['stroke', 'fill', 'stroke_width'], this.apply_styles, this);
         this.listenTo(this.model, "change:selected", this.update_selected);
         this.listenTo(this.model, "change:interactions", this.process_interactions);
         this.listenTo(this.parent, "bg_clicked", () => {
@@ -686,15 +687,18 @@ export class Bars extends Mark {
         //if y is 1-d, each bar should be of 1 color.
         //if y is multi-dimensional, the corresponding values should be of
         //the same color.
+        const stroke = this.model.get("stroke");
         if (this.model.mark_data.length > 0) {
             if (!(this.model.is_y_2d)) {
                 this.d3el.selectAll(".bar")
                     .style("fill", this.get_mark_color.bind(this))
+                    .style("stroke", stroke ? stroke : this.get_mark_color.bind(this))
                     .style("opacity", this.get_mark_opacity.bind(this));
             } else {
                 this.d3el.selectAll(".bargroup")
                     .selectAll(".bar")
                     .style("fill", this.get_mark_color.bind(this))
+                    .style("stroke", stroke ? stroke : this.get_mark_color.bind(this))
                     .style("opacity", this.get_mark_opacity.bind(this));
             }
         }
@@ -702,9 +706,11 @@ export class Bars extends Mark {
         if (this.legend_el) {
             this.legend_el.selectAll(".legendrect")
                 .style("fill", this.get_mark_color.bind(this))
+                .style("stroke", stroke ? stroke : this.get_mark_color.bind(this))
                 .style("opacity", this.get_mark_opacity.bind(this));
             this.legend_el.selectAll(".legendtext")
                 .style("fill", this.get_mark_color.bind(this))
+                .style("stroke", stroke ? stroke : this.get_mark_color.bind(this))
                 .style("opacity", this.get_mark_opacity.bind(this));
         }
     }

--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -688,19 +688,24 @@ export class Bars extends Mark {
         //the same color.
         if (this.model.mark_data.length > 0) {
             if (!(this.model.is_y_2d)) {
-                this.d3el.selectAll(".bar").style("fill", this.get_mark_color.bind(this));
+                this.d3el.selectAll(".bar")
+                    .style("fill", this.get_mark_color.bind(this))
+                    .style("opacity", this.get_mark_opacity.bind(this));
             } else {
                 this.d3el.selectAll(".bargroup")
                     .selectAll(".bar")
-                    .style("fill", this.get_mark_color.bind(this));
+                    .style("fill", this.get_mark_color.bind(this))
+                    .style("opacity", this.get_mark_opacity.bind(this));
             }
         }
         //legend color update
         if (this.legend_el) {
             this.legend_el.selectAll(".legendrect")
-                .style("fill", this.get_mark_color.bind(this));
+                .style("fill", this.get_mark_color.bind(this))
+                .style("opacity", this.get_mark_opacity.bind(this));
             this.legend_el.selectAll(".legendtext")
-                .style("fill", this.get_mark_color.bind(this));
+                .style("fill", this.get_mark_color.bind(this))
+                .style("opacity", this.get_mark_opacity.bind(this));
         }
     }
 
@@ -714,8 +719,8 @@ export class Bars extends Mark {
         const legend_data = this.model.mark_data[0].values.map((data) => {
             return {
                 index: data.sub_index,
-                color: data.color,
-                color_index: data.color_index
+                color_index: data.color_index,
+                opacity_index: data.opacity_index,
             };
         });
         this.legend_el = elem.selectAll(".legend" + this.uuid)
@@ -826,7 +831,7 @@ export class Bars extends Mark {
 
     get_mark_opacity(data, index) {
         // Workaround for the bargroup, the color index is not the same as the bar index
-        return super.get_mark_opacity(data, data.color_index);
+        return super.get_mark_opacity(data, data.opacity_index);
     }
 
     set_x_range() {

--- a/js/src/BarsModel.ts
+++ b/js/src/BarsModel.ts
@@ -163,14 +163,22 @@ export class BarsModel extends markmodel.MarkModel {
         const color_mode = this.get("color_mode");
         const apply_color_to_groups = ((color_mode === "group") ||
                                      (color_mode === "auto" && !(this.is_y_2d)));
+        const apply_color_to_group_element = ((color_mode === "element") ||
+                                     (color_mode === "auto" && this.is_y_2d));
+
         const opacity_mode = this.get("opacity_mode");
         const apply_opacity_to_groups = ((opacity_mode === "group") ||
                                      (opacity_mode === "auto" && !(this.is_y_2d)));
+        const apply_opacity_to_group_element = ((opacity_mode === "element") ||
+                                     (opacity_mode === "auto" && this.is_y_2d));
 
+        let element_idx = 0;
         this.mark_data.forEach(function(single_bar_d, bar_grp_index) {
             single_bar_d.values.forEach(function(bar_d, bar_index) {
-                bar_d.color_index = (apply_color_to_groups) ? bar_grp_index : bar_index;
-                bar_d.opacity_index = (apply_opacity_to_groups) ? bar_grp_index : bar_index;
+                bar_d.color_index = apply_color_to_groups ? bar_grp_index : apply_color_to_group_element ? bar_index : element_idx;
+                bar_d.opacity_index = apply_opacity_to_groups ? bar_grp_index : apply_opacity_to_group_element ? bar_index : element_idx;
+
+                element_idx++;
             });
         });
 

--- a/js/src/BarsModel.ts
+++ b/js/src/BarsModel.ts
@@ -35,6 +35,7 @@ export class BarsModel extends markmodel.MarkModel {
                 color: { dimension: "color" }
             },
             color_mode: "auto",
+            opacity_mode: "auto",
             type: "stacked",
             colors: ['steelblue'],
             padding: 0.05,
@@ -57,7 +58,7 @@ export class BarsModel extends markmodel.MarkModel {
         super.initialize(attributes, options);
         this.is_y_2d = false;
         this.on_some_change(["x", "y", "base"], this.update_data, this);
-        this.on("change:color", function() {
+        this.on_some_change(["color", "opacities", "color_mode", "opacity_mode"], function() {
             this.update_color();
             this.trigger("colors_updated");
         }, this);
@@ -162,18 +163,23 @@ export class BarsModel extends markmodel.MarkModel {
         const color_mode = this.get("color_mode");
         const apply_color_to_groups = ((color_mode === "group") ||
                                      (color_mode === "auto" && !(this.is_y_2d)));
+        const opacity_mode = this.get("opacity_mode");
+        const apply_opacity_to_groups = ((opacity_mode === "group") ||
+                                     (opacity_mode === "auto" && !(this.is_y_2d)));
+
         this.mark_data.forEach(function(single_bar_d, bar_grp_index) {
             single_bar_d.values.forEach(function(bar_d, bar_index) {
                 bar_d.color_index = (apply_color_to_groups) ? bar_grp_index : bar_index;
-                bar_d.color = color[bar_d.color_index];
+                bar_d.opacity_index = (apply_opacity_to_groups) ? bar_grp_index : bar_index;
             });
         });
+
         if(color_scale && color.length > 0) {
-                if(!this.get("preserve_domain").color) {
-                    color_scale.compute_and_set_domain(color, this.model_id + "_color");
-                } else {
-                    color_scale.del_domain([], this.model_id + "_color");
-                }
+            if(!this.get("preserve_domain").color) {
+                color_scale.compute_and_set_domain(color, this.model_id + "_color");
+            } else {
+                color_scale.del_domain([], this.model_id + "_color");
+            }
         }
     }
 


### PR DESCRIPTION
Introduce `opacity_mode` attribute to the `Bar` mark, which behaves like the `color_mode` attribute.

As discussed in https://github.com/bqplot/bqplot/issues/1163, we might need another mode that would allow retrieving the behavior that was in `0.11`.