### PR TITLE
Fix legend not displaying labels on Scatter mark

### DIFF
--- a/js/src/ScatterBase.ts
+++ b/js/src/ScatterBase.ts
@@ -401,7 +401,7 @@ export abstract class ScatterBase extends Mark {
             len = colors.length;
 
         const rect_dim = inter_y_disp * 0.8;
-        const el_added = this.legend_el.enter()
+        const legend = this.legend_el.enter()
           .append("g")
             .attr("class", "legend" + this.uuid)
             .attr("transform", (d, i) => {
@@ -417,9 +417,9 @@ export abstract class ScatterBase extends Mark {
                 this.event_dispatcher("legend_clicked");
             });
 
-        this.draw_legend_elements(el_added, rect_dim)
+        this.draw_legend_elements(legend, rect_dim)
 
-        this.legend_el.append("text")
+        legend.append("text")
           .attr("class","legendtext")
           .attr("x", rect_dim * 1.2)
           .attr("y", rect_dim / 2)
@@ -431,7 +431,7 @@ export abstract class ScatterBase extends Mark {
               return colors[i % len];
           });
 
-        this.legend_el = el_added.merge(this.legend_el);
+        this.legend_el = legend.merge(this.legend_el);
 
         const max_length = d3.max(this.model.get("labels"), (d: any) => {
             return Number(d.length);


### PR DESCRIPTION
We had an issue where the Scatter mark did not display labels passed to the constructor:

```javascript
import bqplot as bqp
import numpy as np
import pandas as pd

sc_x = bqp.LinearScale()
sc_y = bqp.LinearScale()

scatter2 = bqp.Scatter(x=[1,2,3,4,5],
                       y=[1,2,3,4,5],
                       scales={'x': sc_x, 'y': sc_y},
                       display_legend=True,
                       colors=['red'],
                       labels=['Label displayed'],
                   stroke='black')

ax_y = bqp.Axis(label='Security 1 Returns', scale=sc_y, orientation='vertical', tick_format='.0%')
ax_x = bqp.Axis(label='Security 2', scale=sc_x)

bqp.Figure(axes=[ax_x, ax_y], marks=[scatter2], legend_location="top-left", display_legend=True)
```

Before:
![image](https://user-images.githubusercontent.com/24281433/86073985-d359c780-ba39-11ea-9a72-2e8581bd2663.png)

After:
![image](https://user-images.githubusercontent.com/24281433/86074017-e8365b00-ba39-11ea-8e4e-216bae87c04b.png)

