### PR TITLE
Fix scatter plot dot text color appearing orange in JLab dark theme

### DIFF
--- a/js/less/bqplot.less
+++ b/js/less/bqplot.less
@@ -15,6 +15,7 @@
 
 :root {
     --bq-content-font-color: var(--jp-content-font-color1);
+    --bq-content-scatter-font-color: var(--jp-content-font-color1);
     --bq-background: var(--jp-layout-color0);
     --bq-font: 12px sans-serif;
 
@@ -229,7 +230,7 @@
         font: 14px sans-serif;
     }
     text.dot_text {
-        fill: var(--bq-content-font-color);
+        fill: var(--bq-content-scatter-font-color);
     }
     .indsel {
         stroke: red;


### PR DESCRIPTION
Simple fix to the colors applied to any data points with accompanying text, where the text appears orange instead of white, whilst on "Dark Theme" mode in Jupyter Lab. The specific attribute is the "names" attribute in the Scatter object.

```python
import bqplot as b

x_sc = b.LinearScale()
y_sc = b.LinearScale()

x_ax = b.Axis(scale=x_sc, label='X-axis')
y_ax = b.Axis(scale=y_sc, orientation='vertical', label='Y-axis')

scatter = b.Scatter(x=[1,2,3,4,5], y=[1,2,3,4,5], scales={'x': x_sc, 'y': y_sc}, colors=['#1B84ED'], names='1 2 3 4 5'.split())

figure = b.Figure(marks=[scatter], axes=[x_ax, y_ax], scale_x=x_sc, scale_y=y_sc, title='Scatter plot')
figure
```

Before:
![image](https://user-images.githubusercontent.com/24281433/86180741-977a3d00-bae1-11ea-85a5-cb7df9fb4aee.png)


After:
![image](https://user-images.githubusercontent.com/24281433/86180785-a9f47680-bae1-11ea-9d3f-23a13d8a1008.png)
