### PR TITLE
Fix stroke color being set fill color, despite default being "none".

### DIFF
--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -814,7 +814,7 @@ export class Bars extends Mark {
             })
             .selectAll('.bar')
             .style("fill", fill ? this.get_mark_color.bind(this) : "none")
-            .style("stroke", stroke ? stroke : this.get_mark_color.bind(this))
+            .style("stroke", stroke ? stroke : "none")
             .style("opacity", this.get_mark_opacity.bind(this))
             .style("stroke-width", stroke_width);
     }

--- a/js/src/test/bars.ts
+++ b/js/src/test/bars.ts
@@ -153,7 +153,7 @@ describe("bars >", () => {
 
         // No fill
         expect(getFills(rects)).to.eql(['none', 'none', 'none', 'none', 'none', 'none']);
-        expect(getStrokes(rects)).to.eql(['steelblue', 'steelblue', 'steelblue', 'steelblue', 'steelblue', 'steelblue']);
+        expect(getStrokes(rects)).to.eql(['none', 'none', 'none', 'none', 'none', 'none']);
         expect(getStrokeWidth(rects)).to.eql(['1', '1', '1', '1', '1', '1']);
 
         bars.model.set('stroke', 'red');


### PR DESCRIPTION
The stroke color of the Bars mark is set to be that of the fill color, despite a default of "none". This creates an issue when the fill attribute of the Bars mark changes after being constructed, as the stroke does not change with it, leading to unintended behavior. 

Before:
![image](https://user-images.githubusercontent.com/24281433/86201554-b6de8d80-bb14-11ea-8274-6627a2fa1260.png)


After:
![image](https://user-images.githubusercontent.com/24281433/86201606-da093d00-bb14-11ea-8f2d-8f35789c0e0f.png)
