### PR TITLE
Add Scatter mark label positioning offset

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -610,6 +610,12 @@ class Scatter(_ScatterBase):
         Labels for the points of the chart
     display_names: bool (default: True)
         Controls whether names are displayed for points in the scatter
+    name_offset_x: float (default: None)
+        Adds an offset, in pixels, to the horizontal positioning of the 'names'
+        label above each data point
+    name_offset_y: float (default: None)
+        Adds an offset, in pixels, to the vertical positioning of the 'names'
+        label above each data point
     enable_move: bool (default: False)
         Controls whether points can be moved by dragging. Refer to restrict_x,
         restrict_y for more options.
@@ -704,6 +710,8 @@ class Scatter(_ScatterBase):
     names = Array(None, allow_none=True)\
         .tag(sync=True, **array_serialization).valid(array_squeeze)
     display_names = Bool(True).tag(sync=True, display_name='Display names')
+    name_offset_x = Float(allow_none=True).tag(sync=True)
+    name_offset_y = Float(allow_none=True).tag(sync=True)
     fill = Bool(True).tag(sync=True)
     drag_color = Color(None, allow_none=True).tag(sync=True)
     drag_size = Float(5.).tag(sync=True)

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -610,10 +610,10 @@ class Scatter(_ScatterBase):
         Labels for the points of the chart
     display_names: bool (default: True)
         Controls whether names are displayed for points in the scatter
-    name_offset_x: float (default: None)
+    label_display_horizontal_offset: float (default: None)
         Adds an offset, in pixels, to the horizontal positioning of the 'names'
         label above each data point
-    name_offset_y: float (default: None)
+    label_display_vertical_offset: float (default: None)
         Adds an offset, in pixels, to the vertical positioning of the 'names'
         label above each data point
     enable_move: bool (default: False)
@@ -710,8 +710,8 @@ class Scatter(_ScatterBase):
     names = Array(None, allow_none=True)\
         .tag(sync=True, **array_serialization).valid(array_squeeze)
     display_names = Bool(True).tag(sync=True, display_name='Display names')
-    name_offset_x = Float(allow_none=True).tag(sync=True)
-    name_offset_y = Float(allow_none=True).tag(sync=True)
+    label_display_horizontal_offset = Float(allow_none=True).tag(sync=True)
+    label_display_vertical_offset = Float(allow_none=True).tag(sync=True)
     fill = Bool(True).tag(sync=True)
     drag_color = Color(None, allow_none=True).tag(sync=True)
     drag_size = Float(5.).tag(sync=True)

--- a/js/src/Scatter.ts
+++ b/js/src/Scatter.ts
@@ -23,7 +23,7 @@ const bqSymbol: any = markers.symbol;
 export class Scatter extends ScatterBase {
 
     render() {
-
+        
         this.dot = bqSymbol()
           .type(this.model.get("marker"))
           .size(this.model.get("default_size"))
@@ -43,6 +43,7 @@ export class Scatter extends ScatterBase {
         this.listenTo(this.model, "change:default_size", this.update_default_size);
         this.listenTo(this.model, "change:fill", this.update_fill);
         this.listenTo(this.model, "change:display_names", this.update_names);
+        this.listenTo(this.model, "change:name_offset_x change:name_offset_y", this.update_names);
     }
 
     update_colors(model, new_colors) {
@@ -189,8 +190,14 @@ export class Scatter extends ScatterBase {
             .transition("update_names")
             .duration(animation_duration)
             .attr("transform", function(d) {
+                const name_offset_x = that.model.get('name_offset_x');
+                const name_offset_y = that.model.get('name_offset_y');
                 const text_loc = Math.sqrt(that.get_element_size(d)) / 2.0;
-                return "translate(" + (text_loc) + "," + (-text_loc) + ")";})
+                
+                return "translate(" 
+                        + (name_offset_x ? name_offset_x : text_loc) + "," 
+                        + (name_offset_y ? -name_offset_y : -text_loc) + ")";
+            })
             .attr("display", function(d) {
                 return (show_names) ? "inline": "none";
             });

--- a/js/src/Scatter.ts
+++ b/js/src/Scatter.ts
@@ -43,7 +43,7 @@ export class Scatter extends ScatterBase {
         this.listenTo(this.model, "change:default_size", this.update_default_size);
         this.listenTo(this.model, "change:fill", this.update_fill);
         this.listenTo(this.model, "change:display_names", this.update_names);
-        this.listenTo(this.model, "change:name_offset_x change:name_offset_y", this.update_names);
+        this.listenTo(this.model, "change:label_display_horizontal_offset change:label_display_vertical_offset", this.update_names);
     }
 
     update_colors(model, new_colors) {
@@ -190,13 +190,13 @@ export class Scatter extends ScatterBase {
             .transition("update_names")
             .duration(animation_duration)
             .attr("transform", function(d) {
-                const name_offset_x = that.model.get('name_offset_x');
-                const name_offset_y = that.model.get('name_offset_y');
+                const label_display_horizontal_offset = that.model.get('label_display_horizontal_offset');
+                const label_display_vertical_offset = that.model.get('label_display_vertical_offset');
                 const text_loc = Math.sqrt(that.get_element_size(d)) / 2.0;
                 
                 return "translate(" 
-                        + (name_offset_x ? name_offset_x : text_loc) + "," 
-                        + (name_offset_y ? -name_offset_y : -text_loc) + ")";
+                        + (label_display_horizontal_offset ? label_display_horizontal_offset : text_loc) + "," 
+                        + (label_display_vertical_offset ? -label_display_vertical_offset : -text_loc) + ")";
             })
             .attr("display", function(d) {
                 return (show_names) ? "inline": "none";

--- a/js/src/ScatterBaseModel.ts
+++ b/js/src/ScatterBaseModel.ts
@@ -38,8 +38,8 @@ export class ScatterBaseModel extends MarkModel {
             opacity: { dimension: "opacity" },
             rotation: { dimension: "rotation" }
         },
-        name_offset_x: null,
-        name_offset_y: null,
+        label_display_horizontal_offset: null,
+        label_display_vertical_offset: null,
         hovered_style: {},
         unhovered_style: {},
         colors: ['steelblue'],

--- a/js/src/ScatterBaseModel.ts
+++ b/js/src/ScatterBaseModel.ts
@@ -38,6 +38,8 @@ export class ScatterBaseModel extends MarkModel {
             opacity: { dimension: "opacity" },
             rotation: { dimension: "rotation" }
         },
+        name_offset_x: null,
+        name_offset_y: null,
         hovered_style: {},
         unhovered_style: {},
         colors: ['steelblue'],


### PR DESCRIPTION
Requested in #1162, this PR adds horizontal and vertical offsets for the 'names' attribute in the Scatter mark, which overlays labels above each data point. It adds two float traitlets to the python side:

1. ~name_offset_x~ label_display_horizontal_offset (float, value denotes pixels, default value=None)
2. ~name_offset_y~ label_display_vertical_offset (float, value denotes pixels, default value=None)

Both of these are optional, and if no values are passed to the constructor, positioning will fall back to the default behaviour currently exhibited. 

![scatter_labels](https://user-images.githubusercontent.com/24281433/86724478-ad09ce00-bfdd-11ea-9541-6dfda341669a.gif)
