### PR TITLE
Fix Bars mark rendering oversize rectangle / NaN issues

### DIFF
--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -45,7 +45,7 @@ export class Bars extends Mark {
             this.process_interactions();
             this.create_listeners();
             this.compute_view_padding();
-            this.draw();
+            this.draw(false);
         });
     }
 
@@ -80,12 +80,12 @@ export class Bars extends Mark {
         const x_scale = this.scales.x, y_scale = this.scales.y;
         this.listenTo(x_scale, "domain_changed", function () {
             if (!this.model.dirty) {
-                this.draw();
+                this.draw(false);
             }
         });
         this.listenTo(y_scale, "domain_changed", function () {
             if (!this.model.dirty) {
-                this.draw();
+                this.draw(false);
             }
         });
     }
@@ -335,12 +335,6 @@ export class Bars extends Mark {
         const bar_groups = this.d3el.selectAll(".bargroup");
         const bars_sel = bar_groups.selectAll(".bar");
         const animation_duration = animate === true ? this.parent.model.get("animation_duration") : 0;
-        // We need two different transitions because draw_bars can be called in the following cases:
-        // - after the scale has been updated, in that case animate === false
-        // - after the data has been updated, in that case animate === true
-        // However, if we use the same transition, the animation_duration won't be updated and the
-        // "immediate" transition will always be used...
-        const transition_name = animate === true ? "update_bars" : "draw_bars";
         const that = this;
         const orient = this.model.get("orientation");
 
@@ -379,7 +373,7 @@ export class Bars extends Mark {
         let band_width = 1.0;
         if (is_stacked) {
             band_width = Math.max(1.0, this.stacked_scale.bandwidth());
-            bars_sel.transition(transition_name).duration(animation_duration)
+            bars_sel.transition().duration(animation_duration)
                 .attr(dom, 0)
                 .attr(dom_control, band_width.toFixed(2))
                 .attr(rang, function (d) {
@@ -390,7 +384,7 @@ export class Bars extends Mark {
                 });
         } else {
             band_width = Math.max(1.0, this.grouped_scale.bandwidth());
-            bars_sel.transition(transition_name).duration(animation_duration)
+            bars_sel.transition().duration(animation_duration)
                 .attr(dom, function (datum, index) {
                     return that.grouped_scale(index);
                 })

--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -80,12 +80,12 @@ export class Bars extends Mark {
         const x_scale = this.scales.x, y_scale = this.scales.y;
         this.listenTo(x_scale, "domain_changed", function () {
             if (!this.model.dirty) {
-                this.draw(false);
+                this.draw(true);
             }
         });
         this.listenTo(y_scale, "domain_changed", function () {
             if (!this.model.dirty) {
-                this.draw(false);
+                this.draw(true);
             }
         });
     }


### PR DESCRIPTION
This PR fixes an issue where updating the data (with partial NaNs) and Y-domain max traits simultaneously, results in an incorrect, oversize rectangle (see gif). It also adds a quick patch for NaNs which are passed to D3's scale, causing console log errors.

The issue is introduced in:
https://github.com/bqplot/bqplot/commit/e11e193339037ffbeec590eaaae33f50666b6641#diff-7fa0ead9ffe41bff2e2270d08efeb58aR365

It seems like we introduced two different transition names, but without any apparent benefit (which also causes the issue described above), so I have reverted that change.

Before:
![bqplot_bar_bug](https://user-images.githubusercontent.com/24281433/88020862-50c8a300-cae1-11ea-8528-cdb88e6d29e7.gif)

After:
![bqplot_bar_fix](https://user-images.githubusercontent.com/24281433/88021020-97b69880-cae1-11ea-91b9-0424e5b1572a.gif)
