### PR TITLE
Fix color attribute in tooltip

### DIFF
--- a/js/src/BarsModel.ts
+++ b/js/src/BarsModel.ts
@@ -175,9 +175,18 @@ export class BarsModel extends markmodel.MarkModel {
         let element_idx = 0;
         this.mark_data.forEach(function(single_bar_d, bar_grp_index) {
             single_bar_d.values.forEach(function(bar_d, bar_index) {
-                bar_d.color_index = apply_color_to_groups ? bar_grp_index : apply_color_to_group_element ? bar_index : element_idx;
-                bar_d.opacity_index = apply_opacity_to_groups ? bar_grp_index : apply_opacity_to_group_element ? bar_index : element_idx;
-
+                bar_d.color_index = apply_color_to_groups 
+                    ? bar_grp_index 
+                    : apply_color_to_group_element 
+                        ? bar_index 
+                        : element_idx;
+                bar_d.opacity_index = apply_opacity_to_groups 
+                    ? bar_grp_index 
+                    : apply_opacity_to_group_element 
+                        ? bar_index 
+                        : element_idx;
+                bar_d.color = color[bar_d.color_index];
+                
                 element_idx++;
             });
         });


### PR DESCRIPTION
This PR introduces a fix where a `color` attribute passed to a mark constructor does not show in the the tooltip.

```python
from bqplot import (
    Bars, Figure, Tooltip, OrdinalScale, 
    LinearScale, CATEGORY10
)

bar = Bars(x=[[1,2,3]],
           y=[[1,2,3],[4,5,6]], 
           colors=CATEGORY10,
           color_mode='no_group',
           tooltip=Tooltip(fields=['x', 'y', 'color']),
           scales={'x': OrdinalScale(), 'y': LinearScale()}, 
           color=['A', 'B', 'C','D','E','F'])

Figure(marks=[bar])
```

Before:
![bqplot_tooltip_before](https://user-images.githubusercontent.com/24281433/89457711-a70d2700-d71a-11ea-9d44-583e10a14d2a.gif)

After:
![bqplot_tooltip_after](https://user-images.githubusercontent.com/24281433/89458022-33b7e500-d71b-11ea-8d75-00518958a0b9.gif)
