### PR TITLE
Chore: js build polish

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -7565,6 +7565,34 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",

--- a/js/package.json
+++ b/js/package.json
@@ -19,11 +19,13 @@
     "url": "https://github.com/bloomberg/bqplot.git"
   },
   "scripts": {
-    "build": "npm run build:css && npm run build:js && webpack",
+    "build": "npm run build:css && npm run build:js && webpack --mode=production",
     "build:css": "lessc less/bqplot.less css/bqplot.css",
     "build:js": "tsc",
+    "watch": "npm-run-all -p watch:*",
     "watch:js": "tsc --watch",
-    "prepublish": "npm run build",
+    "watch:nbextension": "webpack --watch --mode=development",
+    "prepare": "npm run build",
     "test": "karma start --single-run"
   },
   "devDependencies": {
@@ -52,6 +54,7 @@
     "less": "^3.8.1",
     "less-loader": "^5.0.0",
     "mocha": "^7.1.1",
+    "npm-run-all": "^4.1.3",
     "raw-loader": "~4.0.1",
     "rimraf": "^3.0.2",
     "sinon": "^9.0.2",

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -18,7 +18,8 @@ module.exports = [
         output: {
             filename: 'extension.js',
             path: path.resolve(__dirname, '../bqplot/static'),
-            libraryTarget: 'amd'
+            libraryTarget: 'amd',
+            devtoolModuleFilenameTemplate: 'webpack://jupyter-widgets/bqplot/[resource-path]?[loaders]',
         },
         externals: ['@jupyter-widgets/base'],
         mode: 'production'
@@ -28,7 +29,8 @@ module.exports = [
         output: {
             filename: 'index.js',
             path: path.resolve(__dirname, '../bqplot/static'),
-            libraryTarget: 'amd'
+            libraryTarget: 'amd',
+            devtoolModuleFilenameTemplate: 'webpack://jupyter-widgets/bqplot/[resource-path]?[loaders]',
         },
         devtool: 'source-map',
         module: {
@@ -42,7 +44,8 @@ module.exports = [
         output: {
             filename: 'index.js',
             path: path.resolve(__dirname, './dist/'),
-            libraryTarget: 'amd'
+            libraryTarget: 'amd',
+            devtoolModuleFilenameTemplate: 'webpack://jupyter-widgets/bqplot/[resource-path]?[loaders]',
         },
         devtool: 'source-map',
         module: {


### PR DESCRIPTION
We can now run `npm run watch`
And the dev console gives us a much better path for the files:
![image](https://user-images.githubusercontent.com/1765949/90251414-fac7f080-de3d-11ea-93ee-9fe56730530d.png)
