### PR TITLE
fix: margin_update event listeners were never detached

### DIFF
--- a/js/src/Axis.ts
+++ b/js/src/Axis.ts
@@ -79,7 +79,7 @@ export class Axis extends WidgetView {
         this.listenTo(this.model, "change:visible", this.update_visibility);
         this.model.on_some_change(["side", "orientation"], this.update_display, this);
         this.listenTo(this.model, "change:offset", this.update_offset);
-        this.parent.on("margin_updated", this.parent_margin_updated, this);
+        this.listenTo(this.parent, "margin_updated", this.parent_margin_updated);
     }
 
     update_offset() {

--- a/js/src/ColorAxis.ts
+++ b/js/src/ColorAxis.ts
@@ -57,7 +57,7 @@ class ColorBar extends Axis {
         this.axis_scale.on("highlight_axis", this.highlight, this);
         this.axis_scale.on("unhighlight_axis", this.unhighlight, this);
 
-        this.parent.on("margin_updated", this.parent_margin_updated, this);
+        this.listenTo(this.parent, "margin_updated", this.parent_margin_updated);
         this.listenTo(this.model, "change:visible", this.update_visibility);
         this.listenTo(this.model, "change:label", this.update_label);
         this.model.on_some_change(["side", "orientation"], this.update_display, this);

--- a/js/src/Interaction.ts
+++ b/js/src/Interaction.ts
@@ -41,7 +41,7 @@ export class Interaction extends widgets.WidgetView {
                             this.parent.margin.bottom)
             .attr("pointer-events", "all")
             .attr("visibility", "hidden");
-        this.parent.on("margin_updated", this.relayout, this);
+        this.listenTo(this.parent, "margin_updated", this.relayout);
     }
 
     relayout() {

--- a/js/src/Mark.ts
+++ b/js/src/Mark.ts
@@ -143,7 +143,7 @@ export abstract class Mark extends widgets.WidgetView {
         this.listenTo(this.model, "change:selected_style", this.selected_style_updated);
         this.listenTo(this.model, "change:unselected_style", this.unselected_style_updated);
 
-        this.parent.on("margin_updated", this.relayout, this);
+        this.listenTo(this.parent, "margin_updated", this.relayout);
         this.model.on_some_change(["labels", "display_legend"], function() {
             this.model.trigger("redraw_legend");
         }, this);

--- a/js/src/Selector.ts
+++ b/js/src/Selector.ts
@@ -40,7 +40,7 @@ export abstract class BaseSelector extends Interaction {
     }
 
     create_listeners() {
-        this.parent.on("margin_updated", this.relayout, this);
+        this.listenTo(this.parent, "margin_updated", this.relayout);
         this.listenTo(this.model, "change:selected", this.selected_changed);
         this.listenTo(this.model, "change:marks", this.marks_changed);
         this.listenTo(this.model, "msg:custom", this.handle_custom_messages);


### PR DESCRIPTION
I noticed that in many cases we listen to margin_update (using .on), but never detach it.

In all cases, the context was this, so we could replace it using this.listenTo, which will automatically detach after calling .remove().

