### PR TITLE
Add JupyterLab font color CSS variable to tooltip style

### DIFF
--- a/js/less/bqplot.less
+++ b/js/less/bqplot.less
@@ -313,6 +313,7 @@
 .mark_tooltip {
     pointer-events: none;
     z-index: 1001;
+    color: var(--bq-content-font-color);
     font: var(--bq-font);
     border: var(--jp-border-width) solid var(--jp-border-color1);
     box-shadow: var(--bq-mark-tooltip-box-shadow);


### PR DESCRIPTION
Previously the tooltip object would inherit the font-color attribute from the body element. This was okay when the background was white as the defaul
![fix_tooltip_style](https://user-images.githubusercontent.com/24281433/94769685-7b4b9d80-0367-11eb-9156-c5d904f9c74a.gif)
t fill is black, but not okay when used in conjunction with the dark theme in JupyterLab.