### PR TITLE
Axis: Fix issue when num_ticks is set with a LinearScale

### DIFF
--- a/js/src/Axis.ts
+++ b/js/src/Axis.ts
@@ -652,6 +652,9 @@ export class Axis extends WidgetView {
         if(this.axis_scale.model.type === "ordinal") {
             data_array = this.axis_scale.scale.domain();
         }
+        if(this.axis_scale.model.type === "linear") {
+            data_array = this.axis_scale.scale.ticks();
+        }
         if(num_ticks !== undefined && num_ticks !== null && num_ticks < 2) {
             return [];
         }


### PR DESCRIPTION
Should fix #1213

`num_ticks = 10`
![num10](https://user-images.githubusercontent.com/21197331/94924198-5f5a1000-04bd-11eb-9ef8-617f44dbe0e7.png)

`num_ticks = 5`
![num5](https://user-images.githubusercontent.com/21197331/94924209-66811e00-04bd-11eb-81c3-6cab34326882.png)
