### PR TITLE
fix: preserve scale type in selected attribute, fixes #1224

### DIFF
--- a/js/src/BrushSelector.ts
+++ b/js/src/BrushSelector.ts
@@ -274,8 +274,8 @@ export class BrushSelector extends BrushMixinXYSelector {
             const extent_y = pixel_extent_y.map(this.y_scale.invert.bind(this.y_scale)).sort(sort);
 
             this.update_mark_selected(pixel_extent_x, pixel_extent_y);
-            this.set_selected("selected_x", Float32Array.from(extent_x as ArrayLike<number>));
-            this.set_selected("selected_y", Float32Array.from(extent_y as ArrayLike<number>));
+            this.set_selected("selected_x", this.x_scale.model.typed((extent_x as ArrayLike<number>)));
+            this.set_selected("selected_y", this.y_scale.model.typed((extent_y as ArrayLike<number>)));
             this.touch();
         }
     }
@@ -385,7 +385,7 @@ export class BrushIntervalSelector extends BrushMixinXSelector {
             const extent = pixel_extent.map(this.scale.invert.bind(this.scale)).sort(sort);
 
             this.update_mark_selected(pixel_extent);
-            this.set_selected("selected", Float32Array.from(extent));
+            this.set_selected("selected", this.scale.model.typed(extent));
             this.touch();
         }
     }

--- a/js/src/BrushSelector.ts
+++ b/js/src/BrushSelector.ts
@@ -274,8 +274,8 @@ export class BrushSelector extends BrushMixinXYSelector {
             const extent_y = pixel_extent_y.map(this.y_scale.invert.bind(this.y_scale)).sort(sort);
 
             this.update_mark_selected(pixel_extent_x, pixel_extent_y);
-            this.set_selected("selected_x", this.x_scale.model.typed((extent_x as ArrayLike<number>)));
-            this.set_selected("selected_y", this.y_scale.model.typed((extent_y as ArrayLike<number>)));
+            this.set_selected("selected_x", this.x_scale.model.typedRange((extent_x as ArrayLike<number>)));
+            this.set_selected("selected_y", this.y_scale.model.typedRange((extent_y as ArrayLike<number>)));
             this.touch();
         }
     }
@@ -385,7 +385,7 @@ export class BrushIntervalSelector extends BrushMixinXSelector {
             const extent = pixel_extent.map(this.scale.invert.bind(this.scale)).sort(sort);
 
             this.update_mark_selected(pixel_extent);
-            this.set_selected("selected", this.scale.model.typed(extent));
+            this.set_selected("selected", this.scale.model.typedRange(extent));
             this.touch();
         }
     }

--- a/js/src/DateScaleModel.ts
+++ b/js/src/DateScaleModel.ts
@@ -30,7 +30,7 @@ export class DateScaleModel extends LinearScaleModel{
         };
     }
 
-    typed(values) {
+    typedRange(values) {
         const ar: any = new Float64Array(values.map(Number));
         ar.type = 'date';
         return ar

--- a/js/src/DateScaleModel.ts
+++ b/js/src/DateScaleModel.ts
@@ -30,6 +30,12 @@ export class DateScaleModel extends LinearScaleModel{
         };
     }
 
+    typed(values) {
+        const ar: any = new Float64Array(values.map(Number));
+        ar.type = 'date';
+        return ar
+    }
+
     set_init_state() {
         this.type = "date";
         this.global_min = (new Date()).setTime(0);

--- a/js/src/LinearScaleModel.ts
+++ b/js/src/LinearScaleModel.ts
@@ -31,7 +31,7 @@ export class LinearScaleModel extends ScaleModel {
         };
     }
 
-    typed(values) {
+    typedRange(values) {
         return new Float64Array(values.map(Number));
     }
 

--- a/js/src/LinearScaleModel.ts
+++ b/js/src/LinearScaleModel.ts
@@ -31,6 +31,10 @@ export class LinearScaleModel extends ScaleModel {
         };
     }
 
+    typed(values) {
+        return new Float64Array(values.map(Number));
+    }
+
     set_init_state() {
         this.type = "linear";
         this.global_min = Number.NEGATIVE_INFINITY;

--- a/js/src/OrdinalScaleModel.ts
+++ b/js/src/OrdinalScaleModel.ts
@@ -26,7 +26,7 @@ export class OrdinalScaleModel extends ScaleModel {
         };
     }
 
-    typed(values) {
+    typedRange(values) {
         return new Int32Array(values.map(Number));
     }
 

--- a/js/src/OrdinalScaleModel.ts
+++ b/js/src/OrdinalScaleModel.ts
@@ -26,6 +26,10 @@ export class OrdinalScaleModel extends ScaleModel {
         };
     }
 
+    typed(values) {
+        return new Int32Array(values.map(Number));
+    }
+
     initialize(attributes, options) {
         super.initialize(attributes, options);
     }


### PR DESCRIPTION
Fix #1224

Example:
```python
from bqplot import *
from ipywidgets import *
from bqplot.interacts import *

scale_x1 = DateScale()
scale_y1 = OrdinalScale()
x = np.arange('2020-01-01', '2020-04-01', dtype='datetime64[M]')
scatter1 = Scatter(x=x, y=[3,2,1], scales={'x':scale_x1, 'y':scale_y1})
fig1 = Figure(marks=[scatter1], interaction=BrushSelector(x_scale=scale_x1,
                     y_scale=scale_y1, marks=[scatter1]), background_style={'fill':'#eee'})

fig1
```
![image](https://user-images.githubusercontent.com/1765949/96568196-f4d00f00-12c7-11eb-82e8-6ef2f1182e9d.png)
