### PR TITLE
fix: install map_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup_args = dict(
     license='Apache',
     author='The BQplot Development Team',
     url='https://github.com/bloomberg/bqplot',
+    package_data={'bqplot.map_data': ['*.json']},
     include_package_data=True,
     cmdclass=cmdclass,
     install_requires=[


### PR DESCRIPTION
Fixes #1228
Note that this only matters for the source distribution, the wheel seems to do fine. But I don't understand why the conda-forge distribution *does* include the json files.
@martinRenou maybe you can try to confirm the difference between this branch and master.
(Note that the files are include in the sdist, but a pip install will not put them in the site-packages/bqplot/data_data directory)