### PR TITLE
fix: marks were not removed when changed before views created

### DIFF
--- a/js/src/test/figure.ts
+++ b/js/src/test/figure.ts
@@ -89,4 +89,24 @@ describe("figure >", () => {
 
     });
 
+    it.only("marks removed before created", async function() {
+        const x = {dtype: 'float32', value: new DataView((new Float32Array([0.5, 0.5])).buffer)};
+        const y = {dtype: 'float32', value: new DataView((new Float32Array([2.0, 2.5])).buffer)};
+        const { scatter, figure } = await create_figure_scatter(this.manager, x, y);
+
+        // we start with the scatter and legend
+        expect(figure.fig_marks.node().children).lengthOf(2);
+        // we remove the scatter
+        figure.model.set('marks', [])
+        await Promise.all(figure.mark_views.views)
+        expect(figure.fig_marks.node().children).lengthOf(1);
+        // we set the marks twice without waiting, so we should never see the second scatter in the DOM
+        figure.model.set('marks', [scatter.model, scatter.model])
+        const previousViewsPromise = Promise.all(figure.mark_views.views)
+        figure.model.set('marks', [scatter.model])
+        await Promise.all(figure.mark_views.views)
+        await previousViewsPromise; // we also want to wait for these promises to be resolved so the dummy
+        // DOM node van be removed in the remove event handler in Figure.add_mark
+        expect(figure.fig_marks.node().children).lengthOf(2);
+    });
 });


### PR DESCRIPTION
Closes https://github.com/spacetelescope/jdaviz/issues/270


```python
from bqplot import *
from ipywidgets import *
from bqplot.interacts import *

scale_x1 = DateScale()
scale_y1 = LinearScale()
x = np.arange('2010-01-01', '2020-04-01', dtype='datetime64[D]')
y1 = np.cumsum(np.random.random(x.shape) - 0.5)
line1 = Lines(x=x, y=y1, scales={'x':scale_x1, 'y':scale_y1})
y2 = np.cumsum(np.random.random(x.shape) - 0.5)
line2 = Lines(x=x, y=y2, scales={'x':scale_x1, 'y':scale_y1})

fig1 = Figure(marks=[line1, line2], interaction=BrushSelector(x_scale=scale_x1,
                     y_scale=scale_y1, marks=[line1]), background_style={'fill':'#eee'})

fig1

# next cell, run a few times, and a line mark stays visible

fig1.marks = [line1, line2]
fig1.marks = []
```

Fix coming, would first like to see this fail on CI.