### PR TITLE
Update to jupyter-packaging~=0.7.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.7", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.7.9", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Which includes a fix for `skip_if_exists`.

Follow-up to #1250 using https://github.com/jupyter/jupyter-packaging/pull/58