### PR TITLE
Removed call to super.relayout in FlexLine

### DIFF
--- a/js/src/FlexLine.ts
+++ b/js/src/FlexLine.ts
@@ -135,7 +135,6 @@ export class FlexLine extends Lines {
     }
 
     relayout() {
-        super.relayout();
         this.set_ranges();
 
         const x_scale = this.scales.x, y_scale = this.scales.y;


### PR DESCRIPTION
This removes the JS exceptions when using `FlexLine`.

Now I think `FlexLine` should not inherit from `Line` anymore, they don't have a lot in common, only scales and listeners members. THey don't share common behavior, so it could be worth refactoring this part of bqplot.