### PR TITLE
Feature: enable deduplication of d3-selection for shared browser events

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -72,6 +72,7 @@
     "@lumino/messaging": "^1",
     "@lumino/widgets": "^1",
     "d3": "^5.7.0",
+    "d3-selection": "^1",
     "is-typedarray": "^1.0.0",
     "popper.js": "^1.0.0",
     "three": "^0.91.0",


### PR DESCRIPTION
d3-selection has global state (the event) that is obtained
using `require("d3-selection").event`. If multiple copies of this
js module exists in the frontend, they will not read eachother's
events.

This is required for 3rd party libraries, such as bqplot-image-gl
to be able to read the last d3 event.

Since Jupyter Lab will deduplicate direct dependencies, we only need
to add the d3-selection as an explicit dependency, and it will be
shared with other extensions.