### PR TITLE
Fix Boxplot tooltips

### DIFF
--- a/js/src/Boxplot.ts
+++ b/js/src/Boxplot.ts
@@ -429,7 +429,6 @@ export class Boxplot extends Mark {
     }
 
     draw_mark_paths(parentClass, selector) {
-        const that = this;
         const plotData = this.plotData;
         const outlierData = this.outlierData;
 
@@ -501,17 +500,17 @@ export class Boxplot extends Mark {
                 return (d.boxLower - d.boxUpper);
             })
             .on("click", function(d, i) {
-                return that.event_dispatcher("element_clicked",
+                return this.event_dispatcher("element_clicked",
                                             {"data": d, "index": i});
             })
             .on("mouseover", (d, i) => {
-                that.event_dispatcher("mouse_over", {"data": d, "index": i});
+                this.event_dispatcher("mouse_over", {"data": d, "index": i});
             })
             .on("mousemove", (d, i) => {
-                that.event_dispatcher("mouse_move");
+                this.event_dispatcher("mouse_move");
             })
             .on("mouseout", (d, i) => {
-                that.event_dispatcher("mouse_out");
+                this.event_dispatcher("mouse_out");
             });
 
         //Median line

--- a/js/src/Boxplot.ts
+++ b/js/src/Boxplot.ts
@@ -499,7 +499,7 @@ export class Boxplot extends Mark {
             .attr("height", function (d, i) {
                 return (d.boxLower - d.boxUpper);
             })
-            .on("click", function(d, i) {
+            .on("click", (d, i) => {
                 return this.event_dispatcher("element_clicked",
                                             {"data": d, "index": i});
             })

--- a/js/src/BoxplotModel.ts
+++ b/js/src/BoxplotModel.ts
@@ -48,6 +48,10 @@ export class BoxplotModel extends MarkModel {
         this.update_domains();
     }
 
+    get_data_dict(data, index) {
+        return data.data_dict;
+    }
+
     update_data() {
         let x_data = this.get("x");
         let y_data = this.get("y");


### PR DESCRIPTION
Fix #1236

Fix support for Boxplot and add "x", "median", "q1" and "q3" fields

![boxplot](https://user-images.githubusercontent.com/21197331/108514605-5af38f80-72c4-11eb-9204-a00d2a4dd6ef.png)
