### PR TITLE
Add install.json with uninstall instructions

### DIFF
--- a/install.json
+++ b/install.json
@@ -1,0 +1,5 @@
+{
+  "packageManager": "python",
+  "packageName": "bqplot",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package bqplot"
+}

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ jstargets = [
 data_files_spec = [
     ('share/jupyter/nbextensions/bqplot', 'share/jupyter/nbextensions/bqplot', '*.js'),
     ('share/jupyter/labextensions/bqplot/', 'share/jupyter/labextensions/bqplot/', '**'),
+    ('share/jupyter/labextensions/bqplot/', here, 'install.json'),
     ('etc/jupyter/nbconfig/notebook.d', 'etc/jupyter/nbconfig/notebook.d', 'bqplot.json'),
 ]
 


### PR DESCRIPTION
To give more information to end users on how to uninstall the prebuilt `bqplot` extension for JupyterLab 3.0.

![image](https://user-images.githubusercontent.com/591645/108974228-8cce7280-7685-11eb-848c-b175dd4199ba.png)
