### PR TITLE
Graph Fix arrows

### DIFF
--- a/js/src/Graph.ts
+++ b/js/src/Graph.ts
@@ -66,7 +66,8 @@ export class Graph extends Mark {
       .append('defs')
       .append('marker')
       .attr('id', 'arrow')
-      .attr('refX', 0)
+      .attr('viewBox', '0 0 10 10')
+      .attr('refX', 15)
       .attr('refY', 3)
       .attr('markerWidth', 10)
       .attr('markerHeight', 10)
@@ -298,7 +299,7 @@ export class Graph extends Mark {
       .style('stroke-width', (d: any) => {
         return d.link_width;
       })
-      .attr('marker-mid', directed ? 'url(#arrow)' : null);
+      .attr('marker-end', directed ? 'url(#arrow)' : null);
 
     this.force_layout
       .nodes(this.model.mark_data)


### PR DESCRIPTION
This is is a different approach than https://github.com/bqplot/bqplot/pull/1261 for trying to fix the directed graphs.

The approach here is not pixel perfect, and does not work in the case where the marker is not a circle.

![arrow](https://user-images.githubusercontent.com/21197331/114199166-5b1f1b80-9954-11eb-81a3-406908b6fb37.png)
