### PR TITLE
fix: pan zoom kept panning when mouse was released outside of figure

### DIFF
--- a/js/src/PanZoom.ts
+++ b/js/src/PanZoom.ts
@@ -28,15 +28,19 @@ export class PanZoom extends interaction.Interaction {
     const that = this;
     this.d3el
       .style('cursor', 'move')
-      .on('mousedown', () => {
-        that.mousedown();
-      })
-      .on('mousemove', () => {
-        that.mousemove();
-      })
-      .on('mouseup', () => {
-        that.mouseup();
-      })
+      .call(
+        d3
+          .drag()
+          .on('start', () => {
+            that.mousedown();
+          })
+          .on('drag', () => {
+            that.mousemove();
+          })
+          .on('end', () => {
+            that.mouseup();
+          })
+      )
       .on('mousewheel', () => {
         that.mousewheel();
       })


### PR DESCRIPTION
Fixes #1333 
This is now using the d3-drag module, which takes care of this.