### PR TITLE
fix: under jlab3, d3.event can be null because of duplicate d3 modules

### DIFF
--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -14,13 +14,7 @@
  */
 
 import * as d3 from 'd3';
-// import * as d3 from 'd3';
-// var d3 =Object.assign({}, require("d3-array"), require("d3-scale"), require("d3-selection-multi"));
-// Hack to fix problem with webpack providing multiple d3 objects
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
-
+import { d3GetEvent } from './utils';
 import * as _ from 'underscore';
 import { Mark } from './Mark';
 import { BarData, BarGroupValue, BarsModel } from './BarsModel';

--- a/js/src/Boxplot.ts
+++ b/js/src/Boxplot.ts
@@ -14,9 +14,7 @@
  */
 
 import * as d3 from 'd3';
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
+import { d3GetEvent } from './utils';
 import * as _ from 'underscore';
 import { Mark } from './Mark';
 import { BoxplotModel } from './BoxplotModel';

--- a/js/src/BrushSelector.ts
+++ b/js/src/BrushSelector.ts
@@ -14,10 +14,7 @@
  */
 
 import * as d3 from 'd3';
-// var d3 =Object.assign({}, require("d3-brush"), require("d3-selection"));
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
+import { d3GetEvent } from './utils';
 import * as _ from 'underscore';
 import * as selector from './Selector';
 import * as utils from './utils';

--- a/js/src/Graph.ts
+++ b/js/src/Graph.ts
@@ -14,10 +14,7 @@
  */
 
 import * as d3 from 'd3';
-// var d3 =Object.assign({}, require("d3-array"), require("d3-drag"), require("d3-force"), require("d3-selection"));
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
+import { d3GetEvent } from './utils';
 import * as _ from 'underscore';
 import { Mark } from './Mark';
 import { Scale } from './Scale';

--- a/js/src/GridHeatMap.ts
+++ b/js/src/GridHeatMap.ts
@@ -14,9 +14,7 @@
  */
 
 import * as d3 from 'd3';
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
+import { d3GetEvent } from './utils';
 import * as _ from 'underscore';
 import { Mark } from './Mark';
 import { GridCellData, AxisMode, GridHeatMapModel } from './GridHeatMapModel';

--- a/js/src/Hist.ts
+++ b/js/src/Hist.ts
@@ -15,11 +15,7 @@
 
 import * as _ from 'underscore';
 import * as d3 from 'd3';
-// Hack to fix problem with webpack providing multiple d3 objects
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
-
+import { d3GetEvent } from './utils';
 import * as utils from './utils';
 import { Mark } from './Mark';
 import { HistModel, BinData } from './HistModel';

--- a/js/src/LassoSelector.ts
+++ b/js/src/LassoSelector.ts
@@ -14,10 +14,7 @@
  */
 
 import * as d3 from 'd3';
-// var d3 =Object.assign({}, require("d3-drag"), require("d3-selection"), require("d3-shape"));
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
+import { d3GetEvent } from './utils';
 import * as _ from 'underscore';
 import { BaseXYSelector } from './Selector';
 import * as sel_utils from './selector_utils';

--- a/js/src/Map.ts
+++ b/js/src/Map.ts
@@ -16,9 +16,7 @@
 import * as widgets from '@jupyter-widgets/base';
 import * as d3 from 'd3';
 // var d3 =Object.assign({}, require("d3-selection"), require("d3-zoom"));
-const d3GetEvent = () => {
-  return require('d3-selection').event;
-};
+import { d3GetEvent } from './utils';
 import { Mark } from './Mark';
 import { MapModel } from './MapModel';
 

--- a/js/src/Mark.ts
+++ b/js/src/Mark.ts
@@ -20,10 +20,7 @@ import { MessageLoop } from '@lumino/messaging';
 
 import { Widget } from '@lumino/widgets';
 
-// var d3 =Object.assign({}, require("d3-array"), require("d3-selection"), require("d3-selection-multi"));
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
+import { d3GetEvent } from './utils';
 import * as _ from 'underscore';
 import { MarkModel } from './MarkModel';
 import { Figure } from './Figure';

--- a/js/src/OHLC.ts
+++ b/js/src/OHLC.ts
@@ -17,9 +17,7 @@ import * as d3 from 'd3';
 import * as _ from 'underscore';
 import { Mark } from './Mark';
 import { OHLCModel } from './OHLCModel';
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
+import { d3GetEvent } from './utils';
 
 export class OHLC extends Mark {
   async render() {

--- a/js/src/PanZoom.ts
+++ b/js/src/PanZoom.ts
@@ -15,13 +15,7 @@
 
 import * as widgets from '@jupyter-widgets/base';
 import * as d3 from 'd3';
-// var d3 =Object.assign({}, require("d3-selection"));
-const d3GetEvent = function () {
-  // In JupyterLab we can have require('d3-selection').event
-  // be a different module as the one that is used in d3.on
-  // leading to a null event, for now we can use window.event as fallback.
-  return require('d3-selection').event || window.event;
-}.bind(this);
+import { d3GetEvent } from './utils';
 import * as interaction from './Interaction';
 import * as _ from 'underscore';
 

--- a/js/src/PanZoom.ts
+++ b/js/src/PanZoom.ts
@@ -17,7 +17,10 @@ import * as widgets from '@jupyter-widgets/base';
 import * as d3 from 'd3';
 // var d3 =Object.assign({}, require("d3-selection"));
 const d3GetEvent = function () {
-  return require('d3-selection').event;
+  // In JupyterLab we can have require('d3-selection').event
+  // be a different module as the one that is used in d3.on
+  // leading to a null event, for now we can use window.event as fallback.
+  return require('d3-selection').event || window.event;
 }.bind(this);
 import * as interaction from './Interaction';
 import * as _ from 'underscore';

--- a/js/src/Pie.ts
+++ b/js/src/Pie.ts
@@ -14,10 +14,7 @@
  */
 
 import * as d3 from 'd3';
-// Hack to fix problem with webpack providing multiple d3 objects
-const d3GetEvent = function () {
-  return require('d3-selection').event;
-}.bind(this);
+import { d3GetEvent } from './utils';
 import * as _ from 'underscore';
 import { Mark } from './Mark';
 import { applyStyles, getDate } from './utils';

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -111,3 +111,10 @@ export function applyAttrs(d3el, styles) {
   Object.keys(styles).forEach((key) => d3el.attr(key, styles[key]));
   return d3el;
 }
+
+export function d3GetEvent() {
+  // In JupyterLab we can have require('d3-selection').event
+  // be a different module as the one that is used in d3.on
+  // leading to a null event, for now we can use window.event as fallback.
+  return require('d3-selection').event || window.event;
+}


### PR DESCRIPTION
Similar problem as described in #1276

In my case, I had ipyvolume installed, which had it's own copy of d3 and d3-selection. Bqplot also has its own d3-selection, ipyvolume sets it's d3.event, and bqplot read d3.event from its private module, giving null:


This prevented zooming from working with the PanZoom Interact, giving:
```
PanZoom.js:168 Uncaught TypeError: Cannot read property 'preventDefault' of null
```


According to:
https://developer.mozilla.org/en-US/docs/Web/API/Window/event
This is supported by all browsers.

I think a prettier solution would be to move to d3-selection 2.0, which supports the event being passed as argument. However, I'm not sure that this will work if 3rd party libraries (such as ipyvolume) still have the older version of d3-selection.