### PR TITLE
Add open in Kaggle badge

### DIFF
--- a/examples/Advanced Plotting/Axis Properties.ipynb
+++ b/examples/Advanced Plotting/Axis Properties.ipynb
@@ -1,5 +1,12 @@
 {
  "cells": [
+    {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/bqplot/bqplot/blob/master/examples/Advanced%20Plotting/Axis%20Properties.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>&nbsp;"
+   ]
+  },
   {
    "cell_type": "code",
    "execution_count": null,


### PR DESCRIPTION
Add Kaggle Badge that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480.