### PR TITLE
Keyword "trait" is deprecated in traitlets 5.0

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -132,7 +132,7 @@ class Figure(DOMWidget):
                                                 **widget_serialization)
     scale_x = Instance(Scale).tag(sync=True, **widget_serialization)
     scale_y = Instance(Scale).tag(sync=True, **widget_serialization)
-    title_style = Dict(trait=Unicode()).tag(sync=True)
+    title_style = Dict(value_trait=Unicode()).tag(sync=True)
     background_style = Dict().tag(sync=True)
     legend_style = Dict().tag(sync=True)
     legend_text = Dict().tag(sync=True)

--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -154,7 +154,7 @@ class PanZoom(Interaction):
     """
     allow_pan = Bool(True).tag(sync=True)
     allow_zoom = Bool(True).tag(sync=True)
-    scales = Dict(trait=List(trait=Instance(Scale)))\
+    scales = Dict(value_trait=List(value_trait=Instance(Scale)))\
         .tag(sync=True, **widget_serialization)
 
     _view_name = Unicode('PanZoom').tag(sync=True)

--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -154,7 +154,7 @@ class PanZoom(Interaction):
     """
     allow_pan = Bool(True).tag(sync=True)
     allow_zoom = Bool(True).tag(sync=True)
-    scales = Dict(value_trait=List(value_trait=Instance(Scale)))\
+    scales = Dict(value_trait=List(trait=Instance(Scale)))\
         .tag(sync=True, **widget_serialization)
 
     _view_name = Unicode('PanZoom').tag(sync=True)

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -164,7 +164,7 @@ class Mark(Widget):
         that triggered the tooltip to be visible.
     """
     mark_types = {}
-    scales = Dict(trait=Instance(Scale)).tag(sync=True, **widget_serialization)
+    scales = Dict(value_trait=Instance(Scale)).tag(sync=True, **widget_serialization)
     scales_metadata = Dict().tag(sync=True)
     preserve_domain = Dict().tag(sync=True)
     display_legend = Bool().tag(sync=True, display_name='Display legend')


### PR DESCRIPTION
__DeprecationWarning: Keyword `trait` is deprecated in traitlets 5.0, use `value_trait` instead__

Fixes the following pytest warnings seen [in our GitHub Actions](https://github.com/bqplot/bqplot/actions):
```
=============================== warnings summary ===============================
bqplot/marks.py:167
  /home/runner/work/bqplot/bqplot/bqplot/marks.py:167: DeprecationWarning: Keyword `trait` is deprecated in traitlets 5.0, use `value_trait` instead
    scales = Dict(trait=Instance(Scale)).tag(sync=True, **widget_serialization)

bqplot/interacts.py:157
  /home/runner/work/bqplot/bqplot/bqplot/interacts.py:157: DeprecationWarning: Keyword `trait` is deprecated in traitlets 5.0, use `value_trait` instead
    scales = Dict(trait=List(trait=Instance(Scale)))\

bqplot/figure.py:135
  /home/runner/work/bqplot/bqplot/bqplot/figure.py:135: DeprecationWarning: Keyword `trait` is deprecated in traitlets 5.0, use `value_trait` instead
    title_style = Dict(trait=Unicode()).tag(sync=True)
```