### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/bqplot/default_tooltip.py
+++ b/bqplot/default_tooltip.py
@@ -38,7 +38,7 @@ class Tooltip(DOMWidget):
     ----------
     fields: list (default: [])
         list of names of fields to be displayed in the tooltip
-        All the attributes  of the mark are accesible in the tooltip
+        All the attributes  of the mark are accessible in the tooltip
     formats: list (default: [])
         list of formats to be applied to each of the fields.
         if no format is specified for a field, the value is displayed as it is

--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -53,7 +53,7 @@ def register_interaction(key=None):
 
     If no key is provided, the class name is used as a key. A key is provided
     for each core bqplot interaction type so that the frontend can use this
-    key regardless of the kernal language.
+    key regardless of the kernel language.
     """
     def wrap(interaction):
         name = key if key is not None else interaction.__module__ + \
@@ -203,7 +203,7 @@ class OneDSelector(Selector):
     ----------
     scale: An instance of Scale
         This is the scale which is used for inversion from the pixels to data
-        co-ordinates. This scale is used for setting the selected attribute for
+        coordinates. This scale is used for setting the selected attribute for
         the selector.
     """
     scale = Instance(Scale, allow_none=True, default_value=None)\
@@ -222,11 +222,11 @@ class TwoDSelector(Selector):
     ----------
     x_scale: An instance of Scale
         This is the scale which is used for inversion from the pixels to data
-        co-ordinates in the x-direction. This scale is used for setting the
+        coordinates in the x-direction. This scale is used for setting the
         selected attribute for the selector along with ``y_scale``.
     y_scale: An instance of Scale
         This is the scale which is used for inversion from the pixels to data
-        co-ordinates in the y-direction. This scale is used for setting the
+        coordinates in the y-direction. This scale is used for setting the
         selected attribute for the selector along with ``x_scale``.
     """
     x_scale = Instance(Scale, allow_none=True, default_value=None)\

--- a/bqplot/market_map.py
+++ b/bqplot/market_map.py
@@ -49,7 +49,7 @@ class MarketMap(DOMWidget):
         primary key for the map data. A rectangle is created for each
         unique entry in this array
     groups: numpy.ndarray (default: [])
-        attribute on which the groupby is run. If this is an empty arrray, then
+        attribute on which the groupby is run. If this is an empty array, then
         there is no group by for the map.
     display_text: numpy.ndarray or None(default: None)
         data to be displayed on each rectangle of the map.If this is empty it

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -667,7 +667,7 @@ class Scatter(_ScatterBase):
     icon = 'fa-cloud'
     name = 'Scatter'
 
-    # Scaled attribtes
+    # Scaled attributes
     skew = Array(None, allow_none=True).tag(sync=True, scaled=True,
                                             rtype='Number',
                                             **array_serialization)\

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -1149,7 +1149,7 @@ def _create_selector(int_type, func, trait, **kwargs):
     int_type: type
         The type of selector to be added.
     func: function
-        The call back function. It should take atleast two arguments. The name
+        The call back function. It should take at least two arguments. The name
         of the trait and the value of the trait are passed as arguments.
     trait: string
         The name of the Selector trait whose change triggers the
@@ -1171,7 +1171,7 @@ def brush_int_selector(func=None, trait='selected', **kwargs):
     ----------
 
     func: function
-        The call back function. It should take atleast two arguments. The name
+        The call back function. It should take at least two arguments. The name
         of the trait and the value of the trait are passed as arguments.
     trait: string
         The name of the BrushIntervalSelector trait whose change triggers the
@@ -1190,7 +1190,7 @@ def int_selector(func=None, trait='selected', **kwargs):
     ----------
 
     func: function
-        The call back function. It should take atleast two arguments. The name
+        The call back function. It should take at least two arguments. The name
         of the trait and the value of the trait are passed as arguments.
     trait: string
         The name of the IntervalSelector trait whose change triggers the
@@ -1209,7 +1209,7 @@ def index_selector(func=None, trait='selected', **kwargs):
     ----------
 
     func: function
-        The call back function. It should take atleast two arguments. The name
+        The call back function. It should take at least two arguments. The name
         of the trait and the value of the trait are passed as arguments.
     trait: string
         The name of the IndexSelector trait whose change triggers the
@@ -1228,7 +1228,7 @@ def brush_selector(func=None, trait='selected', **kwargs):
     ----------
 
     func: function
-        The call back function. It should take atleast two arguments. The name
+        The call back function. It should take at least two arguments. The name
         of the trait and the value of the trait are passed as arguments.
     trait: string
         The name of the BrushSelector trait whose change triggers the
@@ -1247,7 +1247,7 @@ def multi_selector(func=None, trait='selected', **kwargs):
     ----------
 
     func: function
-        The call back function. It should take atleast two arguments. The name
+        The call back function. It should take at least two arguments. The name
         of the trait and the value of the trait are passed as arguments.
     trait: string
         The name of the MultiSelector trait whose change triggers the
@@ -1266,7 +1266,7 @@ def lasso_selector(func=None, trait='selected', **kwargs):
     ----------
 
     func: function
-        The call back function. It should take atleast two arguments. The name
+        The call back function. It should take at least two arguments. The name
         of the trait and the value of the trait are passed as arguments.
     trait: string
         The name of the LassoSelector trait whose change triggers the

--- a/bqplot/scales.py
+++ b/bqplot/scales.py
@@ -52,7 +52,7 @@ def register_scale(key=None):
 
     If no key is provided, the class name is used as a key. A key is
     provided for each core bqplot scale type so that the frontend can use
-    this key regardless of the kernal language.
+    this key regardless of the kernel language.
     """
     def wrap(scale):
         label = key if key is not None else scale.__module__ + scale.__name__
@@ -126,7 +126,7 @@ class Mercator(GeoScale):
     rotate: tuple (default: (0, 0))
         Degree of rotation in each axis.
     rtype: (Number, Number) (class-level attribute)
-        This attribute should not be modifed. The range type of a geo
+        This attribute should not be modified. The range type of a geo
         scale is a tuple.
     dtype: type (class-level attribute)
         the associated data type / domain type
@@ -164,7 +164,7 @@ class Albers(GeoScale):
         Specifies the threshold for the projections adaptive resampling to the
         specified value in pixels.
     rtype: (Number, Number) (class-level attribute)
-        This attribute should not be modifed. The range type of a geo
+        This attribute should not be modified. The range type of a geo
         scale is a tuple.
     dtype: type (class-level attribute)
         the associated data type / domain type
@@ -193,7 +193,7 @@ class AlbersUSA(GeoScale):
         Specifies the scale value for the projection
     translate: tuple (default: (600, 490))
     rtype: (Number, Number) (class-level attribute)
-        This attribute should not be modifed. The range type of a geo
+        This attribute should not be modified. The range type of a geo
         scale is a tuple.
     dtype: type (class-level attribute)
         the associated data type / domain type
@@ -342,7 +342,7 @@ class LinearScale(Scale):
     max: float or None (default: None)
         if not None, max is the maximal value of the domain
     rtype: string (class-level attribute)
-        This attribute should not be modifed. The range type of a linear
+        This attribute should not be modified. The range type of a linear
         scale is numerical.
     dtype: type (class-level attribute)
         the associated data type / domain type
@@ -392,7 +392,7 @@ class LogScale(Scale):
     max: float or None (default: None)
         if not None, max is the maximal value of the domain
     rtype: string (class-level attribute)
-        This attribute should not be modifed by the user.
+        This attribute should not be modified by the user.
         The range type of a linear scale is numerical.
     dtype: type (class-level attribute)
         the associated data type / domain type
@@ -422,7 +422,7 @@ class DateScale(Scale):
     domain_class: type (default: Date)
          traitlet type used to validate values in of the domain of the scale.
     rtype: string (class-level attribute)
-        This attribute should not be modifed by the user.
+        This attribute should not be modified by the user.
         The range type of a linear scale is numerical.
     dtype: type (class-level attribute)
         the associated data type / domain type
@@ -449,7 +449,7 @@ class OrdinalScale(Scale):
     domain: list (default: [])
         The discrete values mapped by the ordinal scale
     rtype: string (class-level attribute)
-        This attribute should not be modifed by the user.
+        This attribute should not be modified by the user.
         The range type of a linear scale is numerical.
     dtype: type (class-level attribute)
         the associated data type / domain type
@@ -486,7 +486,7 @@ class ColorScale(Scale):
     extrapolation: {'constant', 'linear'} (default: 'constant')
         How to extrapolate values outside the [min, max] domain.
     rtype: string (class-level attribute)
-        The range type of a color scale is 'Color'. This should not be modifed.
+        The range type of a color scale is 'Color'. This should not be modified.
     dtype: type (class-level attribute)
         the associated data type / domain type
     """
@@ -521,7 +521,7 @@ class DateColorScale(ColorScale):
     mid: Date or None (default: None)
         if not None, mid is the value corresponding to the mid color.
     rtype: string (class-level attribute)
-        This attribute should not be modifed by the user.
+        This attribute should not be modified by the user.
         The range type of a color scale is 'Color'.
     dtype: type (class-level attribute)
         the associated data type / domain type
@@ -549,7 +549,7 @@ class OrdinalColorScale(ColorScale):
     domain: list (default: [])
         The discrete values mapped by the ordinal scales.
     rtype: string (class-level attribute)
-        This attribute should not be modifed by the user.
+        This attribute should not be modified by the user.
         The range type of a color scale is 'color'.
     dtype: type (class-level attribute)
         the associated data type / domain type

--- a/bqplot/traits.py
+++ b/bqplot/traits.py
@@ -41,7 +41,7 @@ def date_to_json(value, obj):
     if value is None:
         return value
     else:
-        # Droping microseconds and only keeping milliseconds to conform
+        # Dropping microseconds and only keeping milliseconds to conform
         # with JavaScript's Data.toJSON's behavior - and prevent bouncing
         # back updates from the front-end.
         return value.strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z'

--- a/examples/Applications/Feature_Vector_Distribution-Iris-Digits.ipynb
+++ b/examples/Applications/Feature_Vector_Distribution-Iris-Digits.ipynb
@@ -69,7 +69,7 @@
     "    group_columns (list): if you want other metadata in the tooltip, these columns will be added\n",
     "    f_lim (dict): this sets the limits for max and min of the plots to a constant \n",
     "        {'max':10, 'min':10}. otherwise defaults to the values of the current features \n",
-    "        which can be missleading. \n",
+    "        which can be misleading. \n",
     "    colors (list): list of colors to use. Internally has a list of 10. If the labels\n",
     "        are longer you will need to pass your own\n",
     "    \n",

--- a/examples/Applications/Outlier Detection.ipynb
+++ b/examples/Applications/Outlier Detection.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook, we create a class `DNA` that leverages the new bqplot canvas based [HeatMap](https://github.com/bloomberg/bqplot/blob/master/examples/Marks/HeatMap.ipynb) along with the ipywidgets Range Slider to help us detect and clean outliers in our data. The class accepts a DataFrame and allows you to visually and programatically filter your outliers. The cleaned DataFrame can then be retrieved through a simple convenience function."
+    "In this notebook, we create a class `DNA` that leverages the new bqplot canvas based [HeatMap](https://github.com/bloomberg/bqplot/blob/master/examples/Marks/HeatMap.ipynb) along with the ipywidgets Range Slider to help us detect and clean outliers in our data. The class accepts a DataFrame and allows you to visually and programmatically filter your outliers. The cleaned DataFrame can then be retrieved through a simple convenience function."
    ]
   },
   {
@@ -182,7 +182,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instead of setting the quantiles by the sliders, we can also set them programatically. Using a range of (5, 95) restricts the data considerably."
+    "Instead of setting the quantiles by the sliders, we can also set them programmatically. Using a range of (5, 95) restricts the data considerably."
    ]
   },
   {

--- a/examples/Introduction.ipynb
+++ b/examples/Introduction.ipynb
@@ -152,7 +152,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Re-run the above cell a few times, the same plot should update everytime. But, thats not the only thing that can be changed once a plot has been rendered. Let's try changing some of the other attributes."
+    "Re-run the above cell a few times, the same plot should update every time. But, that's not the only thing that can be changed once a plot has been rendered. Let's try changing some of the other attributes."
    ]
   },
   {
@@ -198,7 +198,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can call `foo` everytime any attribute of our scatter is changed. Say, the `y` values:"
+    "We can call `foo` every time any attribute of our scatter is changed. Say, the `y` values:"
    ]
   },
   {
@@ -314,7 +314,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most of the time, the actual `Figure` co-ordinates don't really mean anything to us. So, what we need is the visual representation of our `Scale`, which is called an `Axis`."
+    "Most of the time, the actual `Figure` coordinates don't really mean anything to us. So, what we need is the visual representation of our `Scale`, which is called an `Axis`."
    ]
   },
   {

--- a/examples/Marks/Object Model/Label.ipynb
+++ b/examples/Marks/Object Model/Label.ipynb
@@ -28,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Label positioned in data co-ordinates"
+    "## Label positioned in data coordinates"
    ]
   },
   {
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Label positioned in terms of Figure co-ordinates"
+    "## Label positioned in terms of Figure coordinates"
    ]
   },
   {

--- a/examples/Marks/Pyplot/Label.ipynb
+++ b/examples/Marks/Pyplot/Label.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Label positioned in data co-ordinates"
+    "## Label positioned in data coordinates"
    ]
   },
   {
@@ -83,7 +83,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Label positioned in terms of Figure co-ordinates"
+    "## Label positioned in terms of Figure coordinates"
    ]
   },
   {

--- a/examples/Tutorials/Gaussian Density Widget.ipynb
+++ b/examples/Tutorials/Gaussian Density Widget.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# render the compund widget like any other interactive widget\n",
+    "# render the compound widget like any other interactive widget\n",
     "gaussian_density_widget"
    ]
   },

--- a/examples/Tutorials/Object Model.ipynb
+++ b/examples/Tutorials/Object Model.ipynb
@@ -100,7 +100,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Mutiple marks can be rendered in a figure. It's as easy as passing a list of marks when constructing the `Figure` object"
+    "Multiple marks can be rendered in a figure. It's as easy as passing a list of marks when constructing the `Figure` object"
    ]
   },
   {

--- a/examples/Tutorials/Pyplot.ipynb
+++ b/examples/Tutorials/Pyplot.ipynb
@@ -105,7 +105,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Mutiple marks can be rendered in a figure. It's as easy as creating marks one after another. They'll all be added to the same figure!"
+    "Multiple marks can be rendered in a figure. It's as easy as creating marks one after another. They'll all be added to the same figure!"
    ]
   },
   {

--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -917,7 +917,7 @@ export class Bars extends Mark {
           });
         }
       } else if (accelKey) {
-        //If accel is pressed and the bar is not already selcted
+        //If accel is pressed and the bar is not already selected
         //add the bar to the list of selected bars.
         selected.push(index);
       }

--- a/js/src/Graph.ts
+++ b/js/src/Graph.ts
@@ -461,7 +461,7 @@ export class Graph extends Mark {
       selected.splice(elem_index, 1);
     } else {
       if (accelKey) {
-        //If accel is pressed and the bar is not already selcted
+        //If accel is pressed and the bar is not already selected
         //add the bar to the list of selected bars.
         selected.push(index);
       }

--- a/js/src/Hist.ts
+++ b/js/src/Hist.ts
@@ -299,7 +299,7 @@ export class Hist extends Mark {
           });
         }
       } else if (accelKey) {
-        //If accel is pressed and the bar is not already selcted
+        //If accel is pressed and the bar is not already selected
         //add the bar to the list of selected bars.
         selected.push(index);
       }

--- a/js/src/Interaction.ts
+++ b/js/src/Interaction.ts
@@ -32,7 +32,7 @@ export class Interaction extends widgets.WidgetView {
   render() {
     this.parent = this.options.parent;
 
-    // Opaque interation layer
+    // Opaque interaction layer
     this.d3el
       .attr('x', 0)
       .attr('y', 0)

--- a/js/src/MarketMap.ts
+++ b/js/src/MarketMap.ts
@@ -381,7 +381,7 @@ export class MarketMap extends Figure {
         num_items % this.num_rows === 0 ? this.num_cols : this.num_cols + 1;
     }
     // depending on the number of rows, we need to decide when to
-    // switch direction. The below functions tells us where to swtich
+    // switch direction. The below functions tells us where to switch
     // direction.
     this.set_row_limits();
   }
@@ -961,7 +961,7 @@ export class MarketMap extends Figure {
     let num_rows = bottom_row - top_row;
 
     if (elem_remaining !== 0) {
-      // starting corener of the path
+      // starting corner of the path
       this.calc_end_point_source(start_col, start_row, init_x, init_y).forEach(
         (d) => {
           end_points.push(d);

--- a/js/src/OHLC.ts
+++ b/js/src/OHLC.ts
@@ -171,7 +171,7 @@ export class OHLC extends Mark {
           });
         }
       } else if (accelKey) {
-        //If accel is pressed and the candle is not already selcted
+        //If accel is pressed and the candle is not already selected
         //add the candle to the list of selected candles.
         selected.push(index);
       }

--- a/js/src/ScaleModel.ts
+++ b/js/src/ScaleModel.ts
@@ -44,7 +44,7 @@ export abstract class ScaleModel extends WidgetModel {
   }
 
   set_listeners() {
-    // Function to be implementd by inherited classes.
+    // Function to be implemented by inherited classes.
   }
 
   set_domain(domain, id) {

--- a/js/src/ScatterBase.ts
+++ b/js/src/ScatterBase.ts
@@ -398,7 +398,7 @@ export abstract class ScatterBase extends Mark {
       selected.splice(elem_index, 1);
     } else {
       if (accelKey) {
-        //If accel is pressed and the bar is not already selcted
+        //If accel is pressed and the bar is not already selected
         //add the bar to the list of selected bars.
         selected.push(index);
       }

--- a/js/src/test/figure.ts
+++ b/js/src/test/figure.ts
@@ -95,7 +95,7 @@ describe('figure >', () => {
     let context = canvas.getContext('2d');
     let pixel = context.getImageData(test_x, test_y, 1, 1);
     expect(Array.prototype.slice.call(pixel.data)).to.deep.equals(pixel_red);
-    // add a normal (blue) scatter, which should be overlayed on top
+    // add a normal (blue) scatter, which should be overlaid on top
     const scales = {
       x: scatterGlView.model.get('scales').x.toJSON(),
       y: scatterGlView.model.get('scales').y.toJSON(),

--- a/ui-tests/tests/bqplot.test.ts
+++ b/ui-tests/tests/bqplot.test.ts
@@ -120,7 +120,7 @@ describe('bqplot Visual Regression', () => {
     await galata.resetUI();
   });
 
-  afterAll(async () => {
+  after all(async () => {
     galata.context.capturePrefix = '';
   });
 

--- a/ui-tests/tests/bqplot.test.ts
+++ b/ui-tests/tests/bqplot.test.ts
@@ -120,7 +120,7 @@ describe('bqplot Visual Regression', () => {
     await galata.resetUI();
   });
 
-  after all(async () => {
+  afterAll(async () => {
     galata.context.capturePrefix = '';
   });
 


### PR DESCRIPTION
[`codespell --ignore-words-list="afterall,curvelinear,hist" --skip="*.csv,*.json,*.lock"`](https://github.com/codespell-project/codespell)