### PR TITLE
fix: changing an interaction causes it to remove the old view twice

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -976,6 +976,7 @@ export class Figure extends widgets.DOMWidgetView {
     } else {
       if (this.interaction_view) {
         this.interaction_view.remove();
+        this.interaction_view = null;
       }
       return Promise.resolve(null);
     }


### PR DESCRIPTION
Fixes #1359

This caused the event listener fix introduced in https://github.com/bqplot/bqplot/pull/1347 to be removed again.