### PR TITLE
feat: make a PNG export of the figure available in the kernel

### DIFF
--- a/bqplot/figure.py
+++ b/bqplot/figure.py
@@ -156,6 +156,12 @@ class Figure(DOMWidget):
                                    display_name='Animation duration')
     display_toolbar = Bool(default_value=True).tag(sync=True)
 
+    def __init__(self, **kwargs):
+        super(Figure, self).__init__(**kwargs)
+
+        self._upload_png_callback = None
+        self.on_msg(self._handle_custom_msgs)
+
     @default('scale_x')
     def _default_scale_x(self):
         return LinearScale(min=0, max=1, allow_padding=False)
@@ -188,6 +194,23 @@ class Figure(DOMWidget):
         '''
         self.send({"type": "save_svg", "filename": filename})
 
+    def get_png_data(self, callback, scale=None):
+        '''
+        Gets the Figure as a PNG memory view
+
+        Parameters
+        ----------
+        callback: callable
+            Called with the PNG data as the only positional argument.
+
+        scale: float (default: None)
+            Scale up the png resolution when scale > 1, when not given base this on the screen pixel ratio.
+        '''
+        if self._upload_png_callback:
+            raise Exception('get_png_data already in progress')
+        self._upload_png_callback = callback
+        self.send({'type': 'upload_png', 'scale': scale})
+
     @validate('min_aspect_ratio', 'max_aspect_ratio')
     def _validate_aspect_ratio(self, proposal):
         value = proposal['value']
@@ -198,6 +221,13 @@ class Figure(DOMWidget):
            value < self.min_aspect_ratio:
             raise TraitError('setting max_aspect_ratio < min_aspect_ratio')
         return value
+
+    def _handle_custom_msgs(self, _, content, buffers=None):
+        if content.get('event') == 'upload_png':
+            try:
+                self._upload_png_callback(buffers[0])
+            finally:
+                self._upload_png_callback = None
 
     _view_name = Unicode('Figure').tag(sync=True)
     _model_name = Unicode('FigureModel').tag(sync=True)

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -249,6 +249,7 @@ export class Figure extends DOMWidgetView {
     // TODO: remove the save png event mechanism.
     this.model.on('save_png', this.save_png, this);
     this.model.on('save_svg', this.save_svg, this);
+    this.model.on('upload_png', this.upload_png, this);
 
     const figure_scale_promise = this.create_figure_scales();
 
@@ -1196,6 +1197,20 @@ export class Figure extends DOMWidgetView {
       };
       image.src =
         'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(xml)));
+    });
+  }
+
+  async upload_png(model, scale) {
+    const canvas = await this.get_rendered_canvas(scale);
+    canvas.toBlob(async (blob) => {
+      const buff = await blob.arrayBuffer();
+      model.send(
+        {
+          event: 'upload_png',
+        },
+        null,
+        [buff]
+      );
     });
   }
 

--- a/js/src/FigureModel.ts
+++ b/js/src/FigureModel.ts
@@ -70,6 +70,8 @@ export class FigureModel extends widgets.DOMWidgetModel {
       this.trigger('save_png', msg.filename, msg.scale);
     } else if (msg.type === 'save_svg') {
       this.trigger('save_svg', msg.filename);
+    } else if (msg.type === 'upload_png') {
+      this.trigger('upload_png', this, msg.scale);
     }
   }
 


### PR DESCRIPTION
A solution for #1393

Usage:
```python
def on_png_received(data):
    with open('mychart.png', 'bw') as f:
        f.write(data)

figure.get_png_data(on_png_received)
```
