### PR TITLE
chore: fix deprecation warnings/issues and let pytest catch them

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -955,8 +955,8 @@ class Boxplot(Mark):
 
     stroke = Color(None, allow_none=True)\
         .tag(sync=True, display_name='Stroke color')
-    box_fill_color = Color('steelblue', sync=True,
-                           display_name='Fill color for the box')
+    box_fill_color = Color('steelblue')\
+        .tag(sync=True, display_name='Fill color for the box')
     outlier_fill_color = Color('gray').tag(sync=True,
                                            display_name='Outlier fill color')
     opacities = List(trait=Float(1.0, min=0, max=1, allow_none=True))\
@@ -1280,10 +1280,10 @@ class OHLC(Mark):
         'x': {'orientation': 'horizontal', 'dimension': 'x'},
         'y': {'orientation': 'vertical', 'dimension': 'y'}
     }).tag(sync=True)
-    marker = Enum(['candle', 'bar'], default_value='candle',
-                  display_name='Marker').tag(sync=True)
-    stroke = Color(None, display_name='Stroke color', allow_none=True)\
-        .tag(sync=True)
+    marker = Enum(['candle', 'bar'], default_value='candle')\
+        .tag(sync=True, display_name='Marker')
+    stroke = Color(None, allow_none=True)\
+        .tag(sync=True, display_name='Stroke color')
     stroke_width = Float(1.0).tag(sync=True, display_name='Stroke Width')
     colors = List(trait=Color(default_value=None, allow_none=True),
                   default_value=['green', 'red'])\

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 addopts = --nbval --current-env
+
+filterwarnings =
+    error:::bqplot

--- a/tests/binary_serialization_test.py
+++ b/tests/binary_serialization_test.py
@@ -77,7 +77,7 @@ def test_binary_serialize_text():
 def test_dtype_with_str():
     # dtype object is not supported
     text = np.array(['foo', None, 'bar'])
-    assert text.dtype == np.object
+    assert text.dtype == object
     with pytest.raises(ValueError, match='.*Unsupported dtype object*'), pytest.warns(UserWarning):
         array_to_json(text)
     # but if they contain all strings, it should convert them.
@@ -92,7 +92,7 @@ def test_serialize_nested_list():
         [0, 1, 2, 3, 4, 5, 6],
         [0, 1, 2, 2, 3],
         [0, 1, 2, 3, 4, 5, 6, 7],
-    ])
+    ], dtype=object)
 
     serialized_data = array_to_json(data)
 
@@ -116,7 +116,7 @@ def test_serialize_nested_list():
         [0, 1, 2, 3, 4, 5, 6],
         np.array([0, 1, 2, 2, 3]),
         [0, 1, 2, 3]
-    ])
+    ], dtype=object)
 
     serialized_data = array_to_json(data)
 
@@ -139,7 +139,7 @@ def test_serialize_nested_list():
     data = np.array([
         ['Hello', 'Hallo'],
         ['Coucou', 'Hi', 'Ciao']
-    ])
+    ], dtype=object)
 
     serialized_data = array_to_json(data)
 

--- a/tests/marks_test.py
+++ b/tests/marks_test.py
@@ -16,7 +16,7 @@ def test_scatter(figure):
 
 def test_lines(scales):
     # Create a Line chart with data of multiple shapes should work with binary serialization
-    lines = bqplot.Lines(x=[[0, 1], [0, 1, 2]], y=[[0, 1], [1, 0, -1]], scales=scales)
+    lines = bqplot.Lines(x=np.array([[0, 1], [0, 1, 2]], dtype=object), y=np.array([[0, 1], [1, 0, -1]], dtype=object), scales=scales)
 
     lines = bqplot.Lines(x=[[0, 1], [0, 1]], y=[[0, 1], [1, 0]], scales=scales)
     state = lines.get_state()
@@ -34,7 +34,8 @@ def test_lines_ordinal(scale_ordinal, scale_y):
 
 def test_bars(scales):
     # Create a Bar chart with data of multiple shapes should work with binary serialization
-    bars = bqplot.Bars(x=[0, 1], y=[[0, 1], [1, 0, -1]], scales=scales)
+    y = np.array([[0, 1], [1, 0, -1]], dtype=object)
+    bars = bqplot.Bars(x=[0, 1], y=y, scales=scales)
 
     bars = bqplot.Bars(x=[0, 1], y=[[1, 2], [3, 4]], scales=scales)
     state = bars.get_state()


### PR DESCRIPTION
This will clean up not only our test output, but also others, we only got one left from traittypes now:
```
$ py.test tests --pdb                         jdaviz-dev
=============================== test session starts ================================
platform darwin -- Python 3.7.10, pytest-6.1.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/maartenbreddels/src/bqplot, configfile: pytest.ini
plugins: asdf-2.8.0, anyio-3.0.1
collected 10 items                                                                 

tests/binary_serialization_test.py .....                                     [ 50%]
tests/marks_test.py ....                                                     [ 90%]
tests/selector_test.py .                                                     [100%]

================================= warnings summary =================================
../../miniconda3/envs/jdaviz-dev/lib/python3.7/site-packages/traittypes/traittypes.py:24
  /Users/maartenbreddels/miniconda3/envs/jdaviz-dev/lib/python3.7/site-packages/traittypes/traittypes.py:24: DeprecationWarning: 
              Sentinel is not a public part of the traitlets API.
              It was published by mistake, and may be removed in the future.
              
    """)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================== 10 passed, 1 warning in 0.19s ===========================
```