### PR TITLE
fix: properly treat Bar.base with stacked Bars

### DIFF
--- a/js/src/Bars.ts
+++ b/js/src/Bars.ts
@@ -421,7 +421,7 @@ export class Bars extends Mark {
           rang === 'y' ? rangeScale(d.y1) : rangeScale(d.y0)
         )
         .attr(rangeControl, (d: BarGroupValue) =>
-          Math.abs(rangeScale(d.y1 + d.yRef) - rangeScale(d.y1))
+          Math.abs(rangeScale(d.y0) - rangeScale(d.y1))
         );
     } else {
       bandWidth = Math.max(1.0, this.groupedScale.bandwidth());
@@ -461,8 +461,8 @@ export class Bars extends Mark {
           : d3.min([rangeScale(d.y), rangeScale(this.model.baseValue)]);
         rectCoords[domControl] = bandWidth;
         rectCoords[rangeControl] = isStacked
-          ? Math.abs(rangeScale(d.y1 + d.yRef) - rangeScale(d.y1))
-          : Math.abs(rangeScale(this.model.baseValue) - rangeScale(d.yRef));
+          ? Math.abs(rangeScale(d.y0) - rangeScale(d.y1))
+          : Math.abs(rangeScale(this.model.baseValue) - rangeScale(d.y));
         return [
           [rectCoords.x, rectCoords.x + rectCoords.width],
           [rectCoords.y, rectCoords.y + rectCoords.height],


### PR DESCRIPTION
This also allows the use of bars with log scales

# bug

We currently subtract `base` (baseValue in js code) each time from the value, which caused stacked bars to not show correct values. See demonstration of the bug:
![bqplot-bars-base-bug](https://user-images.githubusercontent.com/1765949/145028045-8084c9c1-79a1-4e7b-b94f-5ce46e46c10a.gif)

Code to reproduce:
```python
import bqplot
import numpy as np
import bqplot.pyplot as plt
N = 1000
np.random.seed(42)
log = False
sx = bqplot.LinearScale(min=0, max=4)
sy = bqplot.LinearScale(min=-2, max=6)
if log:
    sy = bqplot.LogScale(min=0.1, max=10)

fig = plt.figure(scale_x=sx, scale_y=sy)
x, y, c = np.random.normal(size=(3, N))
# mark = plt.scatter(x, y**2)
# h = plt.bar(x, y**2)
if log:
    mark = plt.bar([1,2,3], [[1, 1, 1], [2, 3, 4]], base=0.1, color=["orange", "green"], scales={'x': sx, 'y': sy})
else:
    mark = plt.bar([1,2,3], [[1, -1, 1], [2, -3, 4]], base=0, color=["orange", "green"], scales={'x': sx, 'y': sy})
plt.show()
import ipywidgets as widgets
if log:
    slider = widgets.FloatLogSlider(min=-1, max=1.5, step=0.01)
else:
    slider = widgets.FloatSlider(min=-1, max=7)
    
widgets.jslink((mark, 'base'), (slider, 'value'))
slider
```

# solution

I've refactored the code a bit, which makes it easier to comprehend I think, and corrected the double subtraction.

Bars now behave as I expect:
![bqplot-bars-base](https://user-images.githubusercontent.com/1765949/145028210-68ec77df-70d7-4997-bc1a-9ac11066467c.gif)


There are a few issues/cornercase:
 * If base is larger then the first bar value, there is no proper way to display it, so we skip it and print a warning to the console.
 * Using a log scale, negative bars (i.e. where base is larger then the cumulate sum of y) makes totally no sense, but one could argue that's the user error.

