### PR TITLE
feat: log scale support for ScatterGL Mark

### DIFF
--- a/js/shaders/scales.glsl
+++ b/js/shaders/scales.glsl
@@ -1,3 +1,6 @@
+#define SCALE_TYPE_LINEAR 1
+#define SCALE_TYPE_LOG 2
+
 float scale_transform_linear(float domain_value, vec2 range, vec2 domain) {
     float normalized = (domain_value - domain[0]) / (domain[1] - domain[0]);
     float range_value = normalized * (range[1] - range[0]) + range[0];

--- a/js/shaders/scatter-vertex.glsl
+++ b/js/shaders/scatter-vertex.glsl
@@ -101,8 +101,18 @@ attribute float color;
 attribute vec3 color;
 #endif
 
-#define SCALE_X(x) scale_transform_linear(x, range_x, domain_x)
-#define SCALE_Y(x) scale_transform_linear(x, range_y, domain_y)
+#if SCALE_TYPE_x == SCALE_TYPE_LINEAR
+    #define SCALE_X(x) scale_transform_linear(x, range_x, domain_x)
+#elif SCALE_TYPE_x == SCALE_TYPE_LOG
+    #define SCALE_X(x) scale_transform_log(x, range_x, domain_x)
+#endif
+
+#if SCALE_TYPE_y == SCALE_TYPE_LINEAR
+    #define SCALE_Y(x) scale_transform_linear(x, range_y, domain_y)
+#elif SCALE_TYPE_y == SCALE_TYPE_LOG
+    #define SCALE_Y(x) scale_transform_log(x, range_y, domain_y)
+#endif
+
 #define SCALE_SIZE(x) scale_transform_linear(x, range_size, domain_size)
 #define SCALE_ROTATION(x) scale_transform_linear(x, range_rotation, domain_rotation)
 #define SCALE_OPACITY(x) scale_transform_linear(x, range_opacity, domain_opacity)

--- a/js/src/ScatterGL.ts
+++ b/js/src/ScatterGL.ts
@@ -1071,8 +1071,13 @@ export class ScatterGL extends Mark {
     if (!this.y_scale) {
       this.y_scale = this.parent.scale_y;
     }
+
+    // TODO Support ordinal scales?
     const scaleTypeMap = {
+      // Linear scales
+      date: 1,
       linear: 1,
+      // Log scales
       log: 2,
     };
     this.scatter_material.defines[`SCALE_TYPE_x`] =

--- a/js/src/ScatterGL.ts
+++ b/js/src/ScatterGL.ts
@@ -1071,6 +1071,16 @@ export class ScatterGL extends Mark {
     if (!this.y_scale) {
       this.y_scale = this.parent.scale_y;
     }
+    const scaleTypeMap = {
+      linear: 1,
+      log: 2,
+    };
+    this.scatter_material.defines[`SCALE_TYPE_x`] =
+      scaleTypeMap[this.x_scale.model.type];
+    this.scatter_material.defines[`SCALE_TYPE_y`] =
+      scaleTypeMap[this.y_scale.model.type];
+    this.scatter_material.needsUpdate = true;
+
     this.listenTo(this.x_scale, 'domain_changed', function () {
       if (!this.model.dirty) {
         const animate = true;
@@ -1083,6 +1093,7 @@ export class ScatterGL extends Mark {
         this.update_position(animate);
       }
     });
+    this.update_scene();
   }
 
   initialize_additional_scales() {


### PR DESCRIPTION
ScatterGL assumed the scales to be linear, this adds support for log scales.

This would need to be ported to bqplot-gl and master as well.