### PR TITLE
CI: Remove "update snapshots" step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,20 +139,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ui-test-output
-          path: ui-tests/playwright-report
-
-      - name: Update snapshots
-        if: failure()
-        run: |
-          cd ui-tests
-          yarn run test:update
-
-      - name: Upload updated snapshots
-        if: failure()
-        uses: actions/upload-artifact@v2
-        with:
-          name: ipywidgets-updated-snapshots
-          path: ui-tests/tests
+          path: |
+            ui-tests/playwright-report
+            ui-tests/test-results
 
   install:
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
With the new bot, this becomes useless
