### PR TITLE
feat: bqplot.pyplot.clear_figure(key)

### DIFF
--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -1272,6 +1272,18 @@ def clear():
             _context['scale_registry'][key] = {}
 
 
+def clear_figure(key):
+    """Clears the figure tied to given key of all marks axes and grid lines."""
+    fig = _context['figure_registry'].get(key)
+    if fig is not None:
+        fig.marks = []
+        fig.axes = []
+        setattr(fig, 'axis_registry', {})
+        _context['scales'] = {}
+        if key == _context['current_key']:
+            _context['scale_registry'][key] = {}
+
+
 def current_figure():
     """Returns the current context figure."""
     if _context['figure'] is None:


### PR DESCRIPTION
<!--
Thanks for contributing to bqplot!
Please fill out the following items to submit a pull request.
-->

## References

I implemented this downstream because I plotted two different figures on the same panel and I want to clear both of them at the same time before the next plot call. With `bqplot.pyplot.clear()`, it only clears one of them while overplotting the other one in subsequent plot calls.

I am sure this can be more elegant, maybe by introducing new keyword option to `clear()` but I don't want to overcomplicate things being a new contributor. This patch works for me downstream, so I thought would be nice to push it upstream in case others need it.

cc @maartenbreddels 

## Code changes

See diff.

## User-facing changes

New `bqplot.pyplot.clear_figure()` function that takes `key` as argument.

## Backwards-incompatible changes

None.