### PR TITLE
fix: Figure.update_gl shim make for bqplot 0.12 compatibility

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -1301,6 +1301,13 @@ export class Figure extends DOMWidgetView {
     return toolbar;
   }
 
+  /**
+   * @deprecated since 0.13.0 use extra.webGLRender
+   */
+  update_gl() {
+    this.extras.webGLRequestRender();
+  }
+
   axis_views: ViewList<DOMWidgetView>;
   bg: d3.Selection<SVGRectElement, any, any, any>;
   bg_events: d3.Selection<SVGRectElement, any, any, any>;


### PR DESCRIPTION
This makes bqplot-image-gl work with bqplot 0.12.x and future versions.