### PR TITLE
Add browser field to package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -14,6 +14,7 @@
   },
   "license": "Apache-2.0",
   "main": "lib/index.js",
+  "browser": "dist/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/bloomberg/bqplot.git"


### PR DESCRIPTION
## References

`main` currently points to `lib/index.js` which is the transpiled, non-webpacked source. When accessing `bqplot` via a CDN it will direct to `browser` then `main`, so in this PR we point `browser` at the dist code.

CC for details:
https://github.com/voila-dashboards/voila/pull/1154
https://github.com/voila-dashboards/voila/issues/1128

## Code changes

Add `browser` field

## User-facing changes

Should be none.

## Backwards-incompatible changes

Should be none.
