### PR TITLE
docs: Fix a few typos

### DIFF
--- a/bqplot/interacts.py
+++ b/bqplot/interacts.py
@@ -303,7 +303,7 @@ class IndexSelector(OneDSelector):
     color: Color or None (default: None)
         Color of the line representing the index selector.
     line_width: nonnegative integer (default: 0)
-        Width of the line represetning the index selector.
+        Width of the line representing the index selector.
     """
     selected = Array(None, allow_none=True)\
         .tag(sync=True, **array_serialization)

--- a/bqplot/market_map.py
+++ b/bqplot/market_map.py
@@ -81,7 +81,7 @@ class MarketMap(DOMWidget):
         formats for each of the fields for the tooltip data. Order should match
         the order of the tooltip_fields
     freeze_tooltip_location: bool (default: False)
-        if True, freezes the location of the tooltip. If False, tootip will
+        if True, freezes the location of the tooltip. If False, tooltip will
         follow the mouse
     show_groups: bool
         attribute to determine if the groups should be displayed. If set to

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -394,7 +394,7 @@ class Lines(Mark):
     line_style = Enum(['solid', 'dashed', 'dotted', 'dash_dotted'],
                       default_value='solid')\
         .tag(sync=True, display_name='Line style')
-    # TODO: Only Lines have interpolatoin but we can extend for other types of graphs
+    # TODO: Only Lines have interpolation but we can extend for other types of graphs
     interpolation = Enum(['linear', 'basis', 'basis-open',
                           'basis-closed', 'bundle',
                           'cardinal', 'cardinal-open',


### PR DESCRIPTION
There are small typos in:
- bqplot/interacts.py
- bqplot/market_map.py
- bqplot/marks.py

Fixes:
- Should read `tooltip` rather than `tootip`.
- Should read `representing` rather than `represetning`.
- Should read `interpolation` rather than `interpolatoin`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md