### PR TITLE
Add +, x and . as markers

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -578,7 +578,7 @@ class Scatter(_ScatterBase):
         Font-awesome icon for that mark
     name: string (class-level attribute)
         User-friendly name of the mark
-    marker: {'circle', 'cross', 'diamond', 'square', 'triangle-down', 'triangle-up', 'arrow', 'rectangle', 'ellipse', 'plus', 'crosshair'}
+    marker: {'circle', 'cross', 'diamond', 'square', 'triangle-down', 'triangle-up', 'arrow', 'rectangle', 'ellipse', 'plus', 'crosshair', 'point'}
         Marker shape
     colors: list of colors (default: ['steelblue'])
         List of colors of the markers. If the list is shorter than the number
@@ -676,7 +676,7 @@ class Scatter(_ScatterBase):
     # Other attributes
     marker = Enum(['circle', 'cross', 'diamond', 'square', 'triangle-down',
                    'triangle-up', 'arrow', 'rectangle', 'ellipse', 'plus',
-                   'crosshair'],
+                   'crosshair', 'point'],
                   default_value='circle').tag(sync=True, display_name='Marker')
     colors = List(trait=Color(default_value=None, allow_none=True),
                   default_value=['steelblue'])\

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -327,7 +327,7 @@ class Lines(Mark):
         Interpolation scheme used for interpolation between the data points
         provided. Please refer to the svg interpolate documentation for details
         about the different interpolation schemes.
-    marker: {'circle', 'cross', 'diamond', 'square', 'triangle-down', 'triangle-up', 'arrow', 'rectangle', 'ellipse'}
+    marker: {'circle', 'cross', 'diamond', 'square', 'triangle-down', 'triangle-up', 'arrow', 'rectangle', 'ellipse', 'plus', 'crosshair', 'point'}
         Marker shape
     marker_size: nonnegative int (default: 64)
         Default marker size in pixels
@@ -407,7 +407,8 @@ class Lines(Mark):
                 default_value='none')\
         .tag(sync=True, display_name='Fill')
     marker = Enum(['circle', 'cross', 'diamond', 'square', 'triangle-down',
-                   'triangle-up', 'arrow', 'rectangle', 'ellipse'],
+                   'triangle-up', 'arrow', 'rectangle', 'ellipse', 'plus',
+                   'crosshair', 'point'],
                   default_value=None, allow_none=True)\
         .tag(sync=True, display_name='Marker')
     marker_size = Int(64).tag(sync=True, display_name='Default size')

--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -578,7 +578,7 @@ class Scatter(_ScatterBase):
         Font-awesome icon for that mark
     name: string (class-level attribute)
         User-friendly name of the mark
-    marker: {'circle', 'cross', 'diamond', 'square', 'triangle-down', 'triangle-up', 'arrow', 'rectangle', 'ellipse'}
+    marker: {'circle', 'cross', 'diamond', 'square', 'triangle-down', 'triangle-up', 'arrow', 'rectangle', 'ellipse', 'plus', 'crosshair'}
         Marker shape
     colors: list of colors (default: ['steelblue'])
         List of colors of the markers. If the list is shorter than the number
@@ -675,7 +675,8 @@ class Scatter(_ScatterBase):
 
     # Other attributes
     marker = Enum(['circle', 'cross', 'diamond', 'square', 'triangle-down',
-                   'triangle-up', 'arrow', 'rectangle', 'ellipse'],
+                   'triangle-up', 'arrow', 'rectangle', 'ellipse', 'plus',
+                   'crosshair'],
                   default_value='circle').tag(sync=True, display_name='Marker')
     colors = List(trait=Color(default_value=None, allow_none=True),
                   default_value=['steelblue'])\

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -95,7 +95,7 @@ COLOR_CODES = {'b': 'blue', 'g': 'green', 'r': 'red', 'c': 'cyan',
 
 MARKER_CODES = {'o': 'circle', 'v': 'triangle-down', '^': 'triangle-up',
                 's': 'square', 'd': 'diamond', '+': 'cross', 'p': 'plus',
-                'c': 'crosshair'}
+                'c': 'crosshair', '.': 'point'}
 
 
 PY2 = sys.version_info[0] == 2

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -94,7 +94,8 @@ COLOR_CODES = {'b': 'blue', 'g': 'green', 'r': 'red', 'c': 'cyan',
                'm': 'magenta', 'y': 'yellow', 'k': 'black'}
 
 MARKER_CODES = {'o': 'circle', 'v': 'triangle-down', '^': 'triangle-up',
-                's': 'square', 'd': 'diamond', '+': 'cross'}
+                's': 'square', 'd': 'diamond', '+': 'cross', 'p': 'plus',
+                'c': 'crosshair'}
 
 
 PY2 = sys.version_info[0] == 2

--- a/bqplot/pyplot.py
+++ b/bqplot/pyplot.py
@@ -95,7 +95,7 @@ COLOR_CODES = {'b': 'blue', 'g': 'green', 'r': 'red', 'c': 'cyan',
 
 MARKER_CODES = {'o': 'circle', 'v': 'triangle-down', '^': 'triangle-up',
                 's': 'square', 'd': 'diamond', '+': 'cross', 'p': 'plus',
-                'c': 'crosshair', '.': 'point'}
+                'x': 'crosshair', '.': 'point'}
 
 
 PY2 = sys.version_info[0] == 2

--- a/examples/Marks/Object Model/Lines.ipynb
+++ b/examples/Marks/Object Model/Lines.ipynb
@@ -236,7 +236,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `marker` attributes accepts the values `square`, `circle`, `cross`, `diamond`, `square`, `triangle-down`, `triangle-up`, `arrow`, `rectangle`, `ellipse`. Try changing the string above and re-running the cell to see how each `marker` type looks."
+    "The `marker` attributes accepts the values `square`, `circle`, `cross`, `diamond`, `square`, `triangle-down`, `triangle-up`, `arrow`, `rectangle`, `ellipse`, `plus`, `crosshair`, `point`. Try changing the string above and re-running the cell to see how each `marker` type looks."
    ]
   },
   {

--- a/examples/Marks/Pyplot/Lines.ipynb
+++ b/examples/Marks/Pyplot/Lines.ipynb
@@ -188,7 +188,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `marker` attributes accepts the values `square`, `circle`, `cross`, `diamond`, `square`, `triangle-down`, `triangle-up`, `arrow`, `rectangle`, `ellipse`. Try changing the string above and re-running the cell to see how each `marker` type looks."
+    "The `marker` attributes accepts the values `square`, `circle`, `cross`, `diamond`, `square`, `triangle-down`, `triangle-up`, `arrow`, `rectangle`, `ellipse`, `plus`, `crosshair`, `point`. Try changing the string above and re-running the cell to see how each `marker` type looks."
    ]
   },
   {

--- a/js/src/Markers.ts
+++ b/js/src/Markers.ts
@@ -166,6 +166,51 @@ const bqSymbolTypes = d3.map({
       'Z'
     );
   },
+  plus: function (size, skew) {
+    // Use the same radius as square so that this mark is the same size as
+    // the square.
+    const r = Math.sqrt(size) / 2;
+    return (
+      'M0,' +
+      -r +
+      'L' +
+      '0' +
+      ',' +
+      r +
+      'M' +
+      -r +
+      ',' +
+      '0' +
+      'L' +
+      r +
+      ',' +
+      '0'
+    );
+  },
+  crosshair: function (size, skew) {
+    // Use a radius so that this mark is the same size as
+    // the square in the sense that it fits just inside a square
+    // of the same size
+    const r = Math.sqrt(size) / 2;
+    return (
+      'M' +
+      -r +
+      ',' +
+      -r +
+      'L' +
+      r +
+      ',' +
+      r +
+      'M' +
+      -r +
+      ',' +
+      r +
+      'L' +
+      r +
+      ',' +
+      -r
+    );
+  },
 });
 
 function symbolSize() {

--- a/js/src/Markers.ts
+++ b/js/src/Markers.ts
@@ -211,6 +211,27 @@ const bqSymbolTypes = d3.map({
       -r
     );
   },
+  point: function (size) {
+    const pointFactor = 10;
+    const r = Math.sqrt(size / pi / pointFactor);
+    return (
+      'M0,' +
+      r +
+      'A' +
+      r +
+      ',' +
+      r +
+      ' 0 1,1 0,' +
+      -r +
+      'A' +
+      r +
+      ',' +
+      r +
+      ' 0 1,1 0,' +
+      r +
+      'Z'
+    );
+  },
 });
 
 function symbolSize() {


### PR DESCRIPTION
<!--
Thanks for contributing to bqplot!
Please fill out the following items to submit a pull request.
-->

## References

<!-- Note issue numbers this pull request addresses. -->

Closes #1457 

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->
See below 

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

This adds three more scatter marker shapes:

+ `plus`, which makes the shape `+`, with the shortcut `p`
+ `crosshair`, which makes the shape `×`, with the shortcut `x`
+ `point`, which makes a small circle, with the shortcut `.`

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to bqplot public APIs. -->

N/A