### PR TITLE
Pin NodeJS version in ui-testing environment

### DIFF
--- a/test-environment.yml
+++ b/test-environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
     - pip
     - python
+    - nodejs=16
     - yarn
     - ipywidgets >=5.2.2
     - traitlets >=4.3.0


### PR DESCRIPTION
Signed-off-by: Itay Dafna <i.b.dafna@gmail.com>

This PR pins the nodejs to version 16 to avoid issues with node-pre-gyp installations with nodejs 18 on  the galata bot.