### PR TITLE
Fix missing interpolation options

### DIFF
--- a/bqplot/marks.py
+++ b/bqplot/marks.py
@@ -323,7 +323,8 @@ class Lines(Mark):
         in the list will have full opacity, while others will be faded.
     line_style: {'solid', 'dashed', 'dotted', 'dash_dotted'}
         Line style.
-    interpolation: {'linear', 'basis', 'cardinal', 'monotone'}
+    interpolation: {'linear', 'basis', 'basis-open', 'basis-closed', 'bundle', 'cardinal', 'cardinal-open',
+    'cardinal-closed', 'monotone', 'step-before', 'step-after'}
         Interpolation scheme used for interpolation between the data points
         provided. Please refer to the svg interpolate documentation for details
         about the different interpolation schemes.

--- a/js/src/Lines.ts
+++ b/js/src/Lines.ts
@@ -643,7 +643,7 @@ export class Lines extends Mark {
       'cardinal-closed': d3.curveCardinalClosed,
       monotone: d3.curveMonotoneY,
       'step-before': d3.curveStepBefore,
-      'step-after': d3.curveStepAfter
+      'step-after': d3.curveStepAfter,
     };
 
     return curveTypes[this.model.get('interpolation')];

--- a/js/src/Lines.ts
+++ b/js/src/Lines.ts
@@ -635,12 +635,26 @@ export class Lines extends Mark {
     | d3Shape.CurveFactory
     | d3Shape.CurveFactory
     | d3Shape.CurveFactory
+    | d3Shape.CurveFactory
+    | d3Shape.CurveFactory
+    | d3Shape.CurveFactory
+    | d3Shape.CurveFactory
+    | d3Shape.CurveFactory
+    | d3Shape.CurveFactory
+    | d3Shape.CurveFactory
     | d3Shape.CurveFactory {
     const curveTypes = {
       linear: d3.curveLinear,
       basis: d3.curveBasis,
+      'basis-open': d3.curveBasisOpen,
+      'basis-closed': d3.curveBasisClosed,
+      bundle: d3.curveBundle,
       cardinal: d3.curveCardinal,
+      'cardinal-open': d3.curveCardinalOpen,
+      'cardinal-closed': d3.curveCardinalClosed,
       monotone: d3.curveMonotoneY,
+      'step-before': d3.curveStepBefore,
+      'step-after': d3.curveStepAfter
     };
 
     return curveTypes[this.model.get('interpolation')];

--- a/js/src/Lines.ts
+++ b/js/src/Lines.ts
@@ -631,18 +631,7 @@ export class Lines extends Mark {
         : [];
   }
 
-  get_interpolation():
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory
-    | d3Shape.CurveFactory {
+  get_interpolation(): d3Shape.CurveFactory {
     const curveTypes = {
       linear: d3.curveLinear,
       basis: d3.curveBasis,


### PR DESCRIPTION
## References
Closes [#1510 ](https://github.com/bqplot/bqplot/issues/1510)

## Code changes
Add TypeScript references for the missing interpolation types and update the Python docstring to reflect the available options. I used the official d3 [docs](https://github.com/d3/d3-shape/blob/v3.1.0/README.md#line) to check the right references.

## User-facing changes
Add compatibility for 7 interpolation modes that were supported on the Python side, but missing on the JS side:
- basis-open
- basis-closed
- bundle
- cardinal-open
- cardinal-closed
- step-before
- step-after

## Backwards-incompatible changes
N/A
