### PR TITLE
exclude tests top-level package, add some JupyterLab trove classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,9 @@ install_requires =
     bqscales>=0.2.4,<0.3
 classifiers =
     Framework :: Jupyter
+    Framework :: Jupyter :: JupyterLab
+    Framework :: Jupyter :: JupyterLab :: 3
+    Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt
     Intended Audience :: Developers
     Intended Audience :: Science/Research
     Topic :: Multimedia :: Graphics
@@ -35,6 +38,10 @@ classifiers =
 python_requires = >=3.6
 include_package_data = True
 zip_safe = False
+
+[options.packages.find]
+exclude = 
+	tests
 
 [bdist_wheel]
 universal=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
 classifiers =
     Framework :: Jupyter
     Framework :: Jupyter :: JupyterLab
+    Framework :: Jupyter :: JupyterLab :: 2
     Framework :: Jupyter :: JupyterLab :: 3
     Framework :: Jupyter :: JupyterLab :: Extensions
     Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Framework :: Jupyter
     Framework :: Jupyter :: JupyterLab
     Framework :: Jupyter :: JupyterLab :: 3
+    Framework :: Jupyter :: JupyterLab :: Extensions
     Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt
     Intended Audience :: Developers
     Intended Audience :: Science/Research


### PR DESCRIPTION
## References

- addresses https://github.com/conda-forge/bqplot-feedstock/pull/86
  - the feedstock will fail downstream once these are removed: this is fine

## Code changes

- removes the `tests` top-level module, which conflicts with other distributions
  - as it's "last-in-wins," this is not a reliable place to put them
  - some downstreams like `constructor` actively choke on them
- adds some JupyterLab trove classifiers

## User-facing changes

- prospective users would be able to see bqplot in the PyPI browse UI when looking for JupyterLab extensions

## Backwards-incompatible changes

- n/a