### PR TITLE
feature: custom axis labeling from kernel side (tick_labels).

### DIFF
--- a/bqplot/axes.py
+++ b/bqplot/axes.py
@@ -85,6 +85,10 @@ class Axis(BaseAxis):
         If tick_values is None, number of ticks
     tick_values: numpy.ndarray or None (default: None)
         Tick values for the axis
+    tick_labels: dict (default: None)
+        Override the tick labels with a dictionary of {value: label}.
+        Entries are optional, and if not provided, the default tick labels
+        will be used.
     offset: dict (default: {})
         Contains a scale and a value {'scale': scale or None,
         'value': value of the offset}
@@ -128,6 +132,7 @@ class Axis(BaseAxis):
     tick_values = Array(None, allow_none=True)\
         .tag(sync=True, **array_serialization)\
         .valid(array_dimension_bounds(1, 1))
+    tick_labels = Dict(None, allow_none=True).tag(sync=True)
     offset = Dict().tag(sync=True, **widget_serialization)
     label_location = Enum(['middle', 'start', 'end'],
                           default_value='middle').tag(sync=True)

--- a/examples/Advanced Plotting/Axis Properties.ipynb
+++ b/examples/Advanced Plotting/Axis Properties.ipynb
@@ -216,6 +216,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Tick labels\n",
+    "The tick label dictionary can override a label "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Roman labeling\n",
+    "xax.tick_labels = {\n",
+    "    1: 'I',\n",
+    "    3: 'III',\n",
+    "    5: 'V',\n",
+    "    7: 'VII',\n",
+    "    9: 'IX',\n",
+    "    11: 'XI',\n",
+    "    13: 'XIII',\n",
+    "    15: 'XV',\n",
+    "    17: 'XVII',\n",
+    "    19: 'XIX'\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Axis Placement"
    ]
   },

--- a/js/src/Axis.ts
+++ b/js/src/Axis.ts
@@ -75,6 +75,7 @@ export class Axis extends WidgetView {
     // Tick attributes
     this.listenTo(this.model, 'change:tick_values', this.set_tick_values);
     this.listenTo(this.model, 'change:tick_format', this.tickformat_changed);
+    this.listenTo(this.model, 'change:tick_labels', this.tick_labels_changed);
     this.listenTo(this.model, 'change:num_ticks', this.set_tick_values);
     this.listenTo(this.model, 'change:tick_rotate', this.apply_tick_styling);
     this.listenTo(this.model, 'change:tick_style', this.apply_tick_styling);
@@ -221,6 +222,10 @@ export class Axis extends WidgetView {
     this.apply_tick_styling();
   }
 
+  tick_labels_changed() {
+    this.tickformat_changed();
+  }
+
   apply_tick_styling() {
     // Applies current tick styling to all displayed ticks
     const tickText = this.g_axisline.selectAll('.tick text');
@@ -280,6 +285,24 @@ export class Axis extends WidgetView {
   }
 
   generate_tick_formatter() {
+    const default_formatter = this.generate_default_tick_formatter();
+    const tickLabels = this.model.get('tick_labels');
+    if (tickLabels && Object.keys(tickLabels).length > 0) {
+      const formatter = (data) => {
+        let value = tickLabels[data];
+        if (value === undefined) {
+          return default_formatter(data);
+        } else {
+          return value;
+        }
+      };
+      return formatter;
+    } else {
+      return default_formatter;
+    }
+  }
+
+  generate_default_tick_formatter() {
     if (isDateScale(this.axis_scale) || isDateColorScale(this.axis_scale)) {
       if (this.model.get('tick_format')) {
         return d3.utcFormat(this.model.get('tick_format'));

--- a/js/src/AxisModel.ts
+++ b/js/src/AxisModel.ts
@@ -33,6 +33,7 @@ export class AxisModel extends widgets.WidgetModel {
       label: '',
       grid_lines: 'solid',
       tick_format: null,
+      tick_labels: null,
       scale: undefined,
       num_ticks: null,
       tick_values: [],


### PR DESCRIPTION
This allows any custom labeling from the kernel side, and code reuse of labeling code for bqplot and matplotlib.
While I think it's always good to have more scales, there is always a use case of not being able to let the scales+axis do what you want.
Using `tick_values` was already useful, but in combination with the new `tick_labels` (dict that maps values to labels) users have ultimate freedom to position and format the ticks on that axis.

Listening to min and max on the scales, we can update the ticks when we pan (no code example for that yet).

e.g.:
```python
# given a locator and formatter
import numpy as np

def locator(xmin, xmax, ticks=5):
    # Given view interval, returns the ticks to show in data coordinates
    return (xmin + (xmax - xmin) * np.linspace(0, 1, ticks) ** 0.5).astype(int)

def formatter(x, pos=None):
    # Given x values in data coordinates, return the label to show
    return f'{100 * int(x):.1f}nm'
```

We can use that for matplotlib (code by @astrofrog ):
```python
import numpy as np

def locator(xmin, xmax, ticks=5):
    # Given view interval, returns the ticks to show in data coordinates
    return (xmin + (xmax - xmin) * np.linspace(0, 1, ticks) ** 0.5).astype(int)

def formatter(x, pos=None):
    # Given x values in data coordinates, return the label to show
    return f'{100 * int(x):.1f}nm'
```

And also use that in bqplot (yes, react-ipywidget code 😛 )
```python
import react_ipywidgets as react
import react_ipywidgets.bqplot as bq
import react_ipywidgets.ipywidgets as w
import bqplot


@react.component
def Plot():
    ticks, set_ticks = react.use_state(4)

    y = data = np.random.random((64, ))
    x = np.arange(len(y))

    x_min = 0
    x_max = len(data) - 1
    # x is in 'data' coordinates
    x_scale = bq.LinearScale(allow_padding=False, min=x_min, max=x_max)

    # use the same locator as matplotlib code
    tick_values = locator(x_min, x_max, ticks)
    ymax = None
    y_scale = bq.LinearScale(min=0, max=ymax)
    display_legend = True
    color = 'red'
    label = 'test'

    lines = bq.Lines(x=x, y=y, scales={"x": x_scale, "y": y_scale}, stroke_width=3, colors=[color], display_legend=display_legend, labels=[label])

    # same formatted as matplotlib code
    tick_labels = {k:formatter(k) for k in tick_values}
    # using .element because the wrapper does not know tick_labels yet
    x_axis = bqplot.Axis.element(scale=x_scale, tick_labels=tick_labels, tick_values=tick_values)
    y_axis = bq.Axis(scale=y_scale, orientation="vertical")
    with w.VBox() as main:
        w.IntSlider(value=ticks, on_value=set_ticks, description="Ticks")
        bq.Figure(axes=[x_axis, y_axis],
                  marks=[lines],
                  scale_x=x_scale,
                  scale_y=y_scale,
                  layout={"min_width": "800px"})
    return main
        
Plot()
```
Giving:
<img width="943" alt="image" src="https://user-images.githubusercontent.com/1765949/188627471-ca4b3682-9afb-4c8a-acd4-04296f8bc3d5.png">



See also the notebook example, where I added roman numbering:

<img width="1022" alt="image" src="https://user-images.githubusercontent.com/1765949/188628016-6fbaf2c9-2593-442d-a999-19665e9444dc.png">
