### PR TITLE
fix: display and resize plots when not in a lumino context

### DIFF
--- a/examples/Applications/Equity Index Performance/Time Series.ipynb
+++ b/examples/Applications/Equity Index Performance/Time Series.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "### US Equity market performance from 1995 to 2021\n",
-    "In this visualization we'll look S&P 500 Index performance from 1995 to 2021. The visulization consists of two charts:\n",
+    "In this visualization we'll look S&P 500 Index performance from 1995 to 2021. The visualization consists of two charts:\n",
     "* Time Series Chart of Index prices\n",
     "* Histogram of the log returns\n",
     "\n",

--- a/js/package.json
+++ b/js/package.json
@@ -73,7 +73,7 @@
     "sinon": "^9.0.2",
     "sinon-chai": "^3.3.0",
     "style-loader": "^1.2.0",
-    "typescript": "^3.5.2",
+    "typescript": "~4.2.0",
     "webpack": "^5",
     "webpack-cli": "^3.3.12"
   },

--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -28,7 +28,7 @@ import { Scale, ScaleModel } from 'bqscales';
 
 import * as popperreference from './PopperReference';
 import popper from 'popper.js';
-import { applyAttrs, applyStyles, getLuminoWidget } from './utils';
+import { applyAttrs, applyStyles } from './utils';
 import { AxisModel } from './AxisModel';
 import { Mark } from './Mark';
 import { MarkModel } from './MarkModel';
@@ -73,6 +73,29 @@ export class Figure extends DOMWidgetView {
     this._initial_marks_created = new Promise((resolve) => {
       this._initial_marks_created_resolve = resolve;
     });
+
+    this.intersectObserver = new IntersectionObserver(
+      (entries: IntersectionObserverEntry[]) => {
+        if (entries[0].isIntersecting) {
+          this.visible = true;
+          this.debouncedRelayout();
+        } else if (entries[0].rootBounds != null) {
+          /* When 'rootBounds' is null, 'isIntersecting' is 'false', but the plot is visible, so only change 'visible'
+           * if rootBonds is set. I can't find any info on this behaviour. */
+          this.visible = false;
+        }
+      },
+      { threshold: 0 }
+    );
+    this.intersectObserver.observe(this.el);
+
+    this.resizeObserver = new ResizeObserver(
+      (entries: ResizeObserverEntry[]) => {
+        this.debouncedRelayout();
+      }
+    );
+
+    this.resizeObserver.observe(this.el);
 
     super.initialize.apply(this, arguments);
   }
@@ -338,13 +361,6 @@ export class Figure extends DOMWidgetView {
 
     document.body.appendChild(this.tooltip_div.node());
     this.create_listeners();
-
-    // In the classic notebook, we should relayout the figure on
-    // resize of the main window.
-    window.addEventListener('resize', this.debouncedRelayout);
-    this.once('remove', () => {
-      window.removeEventListener('resize', this.debouncedRelayout);
-    });
 
     this.toolbar_div = this.create_toolbar();
     if (this.model.get('display_toolbar')) {
@@ -744,29 +760,6 @@ export class Figure extends DOMWidgetView {
     this.plotarea_height = this.height - this.margin.top - this.margin.bottom;
   }
 
-  processPhosphorMessage(msg) {
-    // @ts-ignore: The following line can only compile with ipywidgets 7
-    this._processLuminoMessage(msg, super.processPhosphorMessage);
-  }
-
-  processLuminoMessage(msg) {
-    this._processLuminoMessage(msg, super.processLuminoMessage);
-  }
-
-  _processLuminoMessage(msg, _super) {
-    _super.call(this, msg);
-
-    switch (msg.type) {
-      case 'resize':
-      case 'after-show':
-      case 'after-attach':
-        if (getLuminoWidget(this).isVisible) {
-          this.debouncedRelayout();
-        }
-        break;
-    }
-  }
-
   relayout() {
     if (!this.relayoutRequested) {
       this.relayoutRequested = true; // avoid scheduling a relayout twice
@@ -779,9 +772,10 @@ export class Figure extends DOMWidgetView {
     const figureSize = this.getFigureSize();
 
     if (
-      this.width == figureSize.width &&
-      this.height == figureSize.height &&
-      !this.should_relayout
+      (this.width == figureSize.width &&
+        this.height == figureSize.height &&
+        !this.should_relayout) ||
+      !this.visible
     ) {
       // Bypass relayout
       return;
@@ -1018,6 +1012,8 @@ export class Figure extends DOMWidgetView {
     if (this.tooltip_div !== undefined) {
       this.tooltip_div.remove();
     }
+    this.intersectObserver.disconnect();
+    this.resizeObserver.disconnect();
     return super.remove.apply(this, arguments);
   }
 
@@ -1360,6 +1356,9 @@ export class Figure extends DOMWidgetView {
   xPaddingArr: { [id: string]: number };
   y_pad_dict: { [id: string]: number };
   yPaddingArr: { [id: string]: number };
+  intersectObserver: IntersectionObserver;
+  resizeObserver: ResizeObserver;
+  visible: boolean;
 
   public webGLCanvas: HTMLCanvasElement;
   public webGLContext: WebGLRenderingContext | null;
@@ -1378,5 +1377,5 @@ export class Figure extends DOMWidgetView {
   // this is public for the test framework, but considered a private API
   public _initial_marks_created: Promise<any>;
   private _initial_marks_created_resolve: Function;
-  private should_relayout: boolean = false;
+  private should_relayout = false;
 }

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -7558,10 +7558,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^3.5.2:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+typescript@~4.2.0:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
+  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
 
 ua-parser-js@^0.7.30:
   version "0.7.33"

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -5,7 +5,7 @@ dependencies:
     - pip
     - python
     - nodejs=16
-    - yarn
+    - yarn <2
     - ipywidgets >=8
     - traitlets >=4.3.0
     - traittypes >=0.0.6


### PR DESCRIPTION
<!--
Thanks for contributing to bqplot!
Please fill out the following items to submit a pull request.
-->

## References
no issue for this yet

## Code changes
Use a combination of `IntersectionObserver` and `ResizeObserver` instead of lumino-events to control relayouts, so this works when lumino-events are not available. This is the case when embedding bqplot in an ipyvuetify-template.

The typescript version was changed to have type support for ResizeObserver.


## User-facing changes
before:

https://user-images.githubusercontent.com/46192475/194905971-9cd46938-2f32-4f91-8c0d-716abe058276.mp4

after:

https://user-images.githubusercontent.com/46192475/194906020-9d7f377f-3c61-4bfe-9f2e-d05a7d8d33ee.mp4

To reproduce:
```python
pip install ipyvuetify ipygoldenlayout
```

```python
import ipyvuetify as v
import traitlets
from ipygoldenlayout import GoldenLayout
import ipywidgets

import numpy as np
import bqplot.pyplot as plt

size = 100
scale = 100.0
np.random.seed(0)
x_data = np.arange(size)
y_data = np.cumsum(np.random.randn(size) * scale)

GoldenLayout()

def make_plot(name):
    fig = plt.figure(title=name)
    plt.plot(y_data)
    fig.layout.min_height = '100%'
    fig.layout.height = '100%'
    fig.layout.max_height = '100%'
    return fig

figs = [make_plot(f"plot{i}") for i in range(3)]

class MultiPlot(v.VuetifyTemplate):
    
    plot1 = traitlets.Any().tag(sync=True, **ipywidgets.widget_serialization)
    plot2 = traitlets.Any().tag(sync=True, **ipywidgets.widget_serialization)
    plot3 = traitlets.Any().tag(sync=True, **ipywidgets.widget_serialization)

    @traitlets.default("template")
    def _template(self):
        return """
        <template>
            <div >
                <golden-layout style="height: 400px">
                  <gl-row>
                    <gl-component title="component1">
                      <jupyter-widget :widget="plot1"></jupyter-widget>
                    </gl-component>
                    <gl-stack>
                      <gl-component title="component2">
                        <jupyter-widget :widget="plot2"></jupyter-widget>
                      </gl-component>
                      <gl-component title="component3" >
                        <jupyter-widget :widget="plot3"></jupyter-widget>  
                      </gl-component>
                    </gl-stack>
                  </gl-row>
                </golden-layout>
            </div>
        </template>
        """
    
MultiPlot(plot1=figs[0], plot2=figs[1], plot3=figs[2])
```

A similar PR, but without resize support: #1029 