### PR TITLE
Fix version so dev version registers properly

### DIFF
--- a/bqplot/_version.py
+++ b/bqplot/_version.py
@@ -1,4 +1,4 @@
-version_info = (0, 12, 30, 'final', 0)
+version_info = (0, 13, 0, 'dev', 0)
 
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 


### PR DESCRIPTION
I don't know if this is the proper fix but the hardcoded version is actually older than the released version, causing pip confusion when someone tries to install the dev version of bqplot.

Ideally, using `setuptools_scm` would fix this but I am not familiar with your build infrastructure, so I don't know how to set it up properly.

If you want to use `setuptools_scm`, feel free to open another PR to do it and close this without merge. Thanks!