### PR TITLE
fix: figure is not updating when margins change

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -288,7 +288,10 @@ export class Figure extends DOMWidgetView {
     // TODO: move to the model
     this.model.on_some_change(
       ['fig_margin', 'min_aspect_ratio', 'max_aspect_ratio'],
-      this.debouncedRelayout,
+      () => {
+        this.should_relayout = true;
+        this.debouncedRelayout();
+      },
       this
     );
     this.model.on_some_change(
@@ -775,10 +778,15 @@ export class Figure extends DOMWidgetView {
     this.relayoutRequested = false; // reset relayout request
     const figureSize = this.getFigureSize();
 
-    if (this.width == figureSize.width && this.height == figureSize.height) {
+    if (
+      this.width == figureSize.width &&
+      this.height == figureSize.height &&
+      !this.should_relayout
+    ) {
       // Bypass relayout
       return;
     }
+    this.should_relayout = false;
 
     this.width = figureSize.width;
     this.height = figureSize.height;
@@ -1370,4 +1378,5 @@ export class Figure extends DOMWidgetView {
   // this is public for the test framework, but considered a private API
   public _initial_marks_created: Promise<any>;
   private _initial_marks_created_resolve: Function;
+  private should_relayout: boolean = false;
 }


### PR DESCRIPTION
<!--
Thanks for contributing to bqplot!
Please fill out the following items to submit a pull request.
-->

## References

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Extend bypass relayout logic to include margins

## User-facing changes

Changing margins results in an updated figure

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

To reproduce:
```python
import numpy as np
import bqplot.pyplot as plt

size = 100
scale = 100.0
np.random.seed(0)
x_data = np.arange(size)
y_data = np.cumsum(np.random.randn(size) * scale)

fig = plt.figure()
plt.plot(y_data)
fig
```

```python
fig.fig_margin = {'top': 0, 'bottom': 0, 'left': 30, 'right': 0}
```