### PR TITLE
fix: remove numpy upper bound pin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ install_requires =
     ipywidgets>=7.5.0,<9
     traitlets>=4.3.0
     traittypes>=0.0.6
-    numpy>=1.10.4,<2.0.0
+    numpy>=1.10.4
     pandas>=1.0.0,<3.0.0
 classifiers =
     Framework :: Jupyter


### PR DESCRIPTION
We are unlikely to ever be affected by breaking changes in numpy because we do not use a large surface area.

See https://iscinumpy.dev/post/bound-version-constraints/#tldr
 'Anyone can fix a missing cap, but users cannot fix an over
  restrictive cap causing solver errors.'

Fixes https://github.com/spacetelescope/jdaviz/issues/2259
