### PR TITLE
fix: background color of figure was not computed properly

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -21,7 +21,7 @@ import * as popperreference from './PopperReference';
 import popper from 'popper.js';
 import * as THREE from 'three';
 import { Dict, WidgetModel, WidgetView } from '@jupyter-widgets/base';
-import { applyAttrs, applyStyles } from './utils';
+import { applyAttrs, applyStyles, getEffectiveBackgroundColor } from './utils';
 import { Scale } from './Scale';
 import { ScaleModel } from './ScaleModel';
 import { AxisModel } from './AxisModel';
@@ -1106,7 +1106,7 @@ export class Figure extends widgets.DOMWidgetView {
       svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
       svg.setAttribute('width', this.width);
       svg.setAttribute('height', this.height);
-      svg.style.background = window.getComputedStyle(document.body).background;
+      svg.style.backgroundColor = getEffectiveBackgroundColor(this.el);
 
       const computedStyle = window.getComputedStyle(this.el);
       const cssCode =

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -124,3 +124,23 @@ export function d3GetEvent() {
 export function getLuminoWidget(ipywidget: DOMWidgetView) {
   return ipywidget.pWidget ? ipywidget.pWidget : ipywidget.luminoWidget;
 }
+
+export function getEffectiveBackgroundColor(element) {
+  if (!element) {
+    // If no element provided or we have traversed beyond the body or html,
+    // we default to white as the background color.
+    return 'rgb(255, 255, 255)';
+  }
+
+  const style = window.getComputedStyle(element);
+  const bgColor = style.backgroundColor;
+  const hasBackgroundImage = style.backgroundImage !== 'none';
+  const isTransparent =
+    bgColor === 'transparent' || bgColor === 'rgba(0, 0, 0, 0)';
+
+  if (!isTransparent || hasBackgroundImage) {
+    return bgColor;
+  }
+
+  return getEffectiveBackgroundColor(element.parentElement);
+}


### PR DESCRIPTION
On the screen, it is not the computed background color that is seen by a user. Since DOM elements can be transparent, the background color might be one of the parent elements. This is why we need to traverse the DOM tree to find the background color of the first non-transparent parent element.

A more sophisticated solution would be to also use blending when there is a non-fully transparent background color. I think that might be a bit overkill for now.

See also https://github.com/spacetelescope/jdaviz/pull/2264#issuecomment-1612052525

