### PR TITLE
Backport #1603 fix: background color of figure was not computed properly (#1603)

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -28,7 +28,7 @@ import { Scale, ScaleModel } from 'bqscales';
 
 import * as popperreference from './PopperReference';
 import popper from 'popper.js';
-import { applyAttrs, applyStyles } from './utils';
+import { applyAttrs, applyStyles, getEffectiveBackgroundColor } from './utils';
 import { AxisModel } from './AxisModel';
 import { Mark } from './Mark';
 import { MarkModel } from './MarkModel';
@@ -1105,7 +1105,7 @@ export class Figure extends DOMWidgetView {
     svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
     svg.setAttribute('width', this.width);
     svg.setAttribute('height', this.height);
-    svg.style.background = window.getComputedStyle(document.body).background;
+    svg.style.background = getEffectiveBackgroundColor(this.el);
 
     const computedStyle = window.getComputedStyle(this.el);
     const cssCode =

--- a/js/src/utils.ts
+++ b/js/src/utils.ts
@@ -124,3 +124,23 @@ export function d3GetEvent() {
 export function getLuminoWidget(ipywidget: DOMWidgetView) {
   return ipywidget.pWidget ? ipywidget.pWidget : ipywidget.luminoWidget;
 }
+
+export function getEffectiveBackgroundColor(element) {
+  if (!element) {
+    // If no element provided or we have traversed beyond the body or html,
+    // we default to white as the background color.
+    return 'rgb(255, 255, 255)';
+  }
+
+  const style = window.getComputedStyle(element);
+  const bgColor = style.backgroundColor;
+  const hasBackgroundImage = style.backgroundImage !== 'none';
+  const isTransparent =
+    bgColor === 'transparent' || bgColor === 'rgba(0, 0, 0, 0)';
+
+  if (!isTransparent || hasBackgroundImage) {
+    return bgColor;
+  }
+
+  return getEffectiveBackgroundColor(element.parentElement);
+}


### PR DESCRIPTION
On the screen, it is not the computed background color that is seen by a user. Since DOM elements can be transparent, the background color might be one of the parent elements. This is why we need to traverse the DOM tree to find the background color of the first non-transparent parent element.

A more sophisticated solution would be to also use blending when there is a non-fully transparent background color. I think that might be a bit overkill for now.

See also https://github.com/spacetelescope/jdaviz/pull/2264#issuecomment-1612052525

<!--
Thanks for contributing to bqplot!
Please fill out the following items to submit a pull request.
-->

## References

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to bqplot public APIs. -->
