### PR TITLE
fix: set domain to (0, 1) when no data is present

### DIFF
--- a/js/src/LinearScaleModel.ts
+++ b/js/src/LinearScaleModel.ts
@@ -78,6 +78,17 @@ export class LinearScaleModel extends ScaleModel {
 
   update_domain() {
     const that = this;
+    // if all domains are empty, we reset to the default domain of (0, 1)
+    if (
+      _.every(this.domains, (d) => {
+        return d.length === 0;
+      })
+    ) {
+      this.domain = this.reverse ? [1, 0] : [0, 1];
+      this.trigger('domain_changed', this.domain);
+      return;
+    }
+
     const min = !this.min_from_data
       ? this.min
       : d3.min(

--- a/ui-tests/tests/notebooks/lines_update.ipynb
+++ b/ui-tests/tests/notebooks/lines_update.ipynb
@@ -138,6 +138,26 @@
    "source": [
     "lines.labels_visibility = 'label'"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7444d361-f8f3-4641-88ef-fbe84450bfb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines.x, lines.y = [], []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "481f09e7-f7a9-4393-8388-a608b216ef41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines.x, lines.y = np.arange(len(y1)), [y1, y2, y3, y4]"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Fixes https://github.com/bqplot/bqplot/issues/1614

If no data is present, a scale has a domain of (0, 1) but if we remove the data afterwards (set it to an empty array) , we set it to (-inf, +inf) which causes rendering issues and make the bqplot figure unable to restore itself.
It is more consistent to behave like no data was passed in, and use (0, 1) for the domain.
