### PR TITLE
fix: domain should not be reset when min/max are set

### DIFF
--- a/js/src/LinearScaleModel.ts
+++ b/js/src/LinearScaleModel.ts
@@ -78,8 +78,9 @@ export class LinearScaleModel extends ScaleModel {
 
   update_domain() {
     const that = this;
-    // if all domains are empty, we reset to the default domain of (0, 1)
+    // if all domains are empty, and min or max are not set, we reset to the default domain of (0, 1)
     if (
+      (this.min_from_data || this.max_from_data) &&
       _.every(this.domains, (d) => {
         return d.length === 0;
       })

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -15,7 +15,7 @@ dependencies:
     - jupyterlab=3.2
     - notebook
     - jupyter-packaging
-    - pytest
+    - pytest <8
     - nbval
     - pytest-cov
     - selenium


### PR DESCRIPTION
In #1619 we reset the domain to (0, 1) when no data is present. However, this only matters when the min/max are not set.

Issue found in https://github.com/spacetelescope/jdaviz/pull/2661
