### PR TITLE
fix: save_png doesn't work when character \xa0 is used

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -1352,8 +1352,8 @@ export class Figure extends DOMWidgetView {
       .attr('href', data_url);
 
     svg.insertBefore(defs, svg.firstChild);
-    // Getting the outer HTML
-    return svg.outerHTML;
+    // Getting the outer HTML. .outerHTML replaces '\xa0' with '&nbsp;', which is invalid in SVG
+    return svg.outerHTML.replace(/&nbsp;/g, '\xa0');
   }
 
   async get_rendered_canvas(scale): Promise<HTMLCanvasElement> {


### PR DESCRIPTION
<!--
Thanks for contributing to bqplot!
Please fill out the following items to submit a pull request.
-->
The character `\xa0` is converted to `&nbsp;` when .outerHTML() is called, causing an error in the data-URL where the outer HTML is used.

## Code changes

Revert `&nbps;`, generated by `.outerHtml()`, back to the original character `\xa0`. 

## User-facing changes

`save_png()` will now work when `\xa0` is used.

## Steps to reproduce

Run the following:
```python
from bqplot import *

x_sc = LinearScale()
y_sc = LinearScale()

scatter_chart = Scatter(x=x_data, y=y_data, scales={'x': x_sc, 'y': y_sc})

x_ax = Axis(label='X', scale=x_sc)
y_ax = Axis(label='Y', scale=y_sc, orientation='vertical')

fig = Figure(title="Ti \xa0 tle", marks=[scatter_chart], axes=[x_ax, y_ax])
fig
```

```python
fig.save_png("fig.png")
```

Notice the save dialog is not appearing.

The dataURL produced with `&nbsp;`:
<img width="949" alt="Screenshot 2024-04-30 at 17 11 00" src="https://github.com/bqplot/bqplot/assets/46192475/7b11c8a6-d5a5-45a3-9f13-5d0e67eafb5a">
