### PR TITLE
Backport PR bqplot#1644: fix: save_png doesn't work when character \xa0 is used (#1644)

### DIFF
--- a/js/src/Figure.ts
+++ b/js/src/Figure.ts
@@ -1162,8 +1162,8 @@ export class Figure extends widgets.DOMWidgetView {
       }
 
       svg.insertBefore(defs, svg.firstChild);
-      // Getting the outer HTML
-      return svg.outerHTML;
+      // Getting the outer HTML. .outerHTML replaces '\xa0' with '&nbsp;', which is invalid in SVG
+      return svg.outerHTML.replace(/&nbsp;/g, '\xa0');
     });
   }
 


### PR DESCRIPTION
The character \xa0 is converted to &nbsp; when .outerHTML() is called, causing an error in the data-URL where the outer HTML is used.

(cherry picked from commit 4d5c2932d8d55e1af96e7129f0550c18c0c3b977)

<!--
Thanks for contributing to bqplot!
Please fill out the following items to submit a pull request.
-->

## References

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to bqplot public APIs. -->
