### PR TITLE
BLD: Use modern jupyter_packaging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.9", "jupyterlab==4.*", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging>=0.12.2", "jupyterlab==4.*", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging>=0.12.2", "jupyterlab==4.*", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.12.2", "jupyterlab==4.*", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Use modern jupyter_packaging so this can build in Python 3.13

Example failure log: https://github.com/spacetelescope/jdaviz/actions/runs/11278687750/job/31367720187?pr=3210

xref https://github.com/spacetelescope/jdaviz/pull/3210

cc @maartenbreddels @dhomeier