### PR TITLE
fix: ascent is now in scipy.datasets instead of scipy.misc

### DIFF
--- a/examples/Marks/Object Model/HeatMap.ipynb
+++ b/examples/Marks/Object Model/HeatMap.ipynb
@@ -101,7 +101,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scipy.misc import ascent\n",
+    "from scipy.datasets import ascent\n",
     "Z = ascent()\n",
     "Z = Z[::-1, :] \n",
     "aspect_ratio = Z.shape[1]/Z.shape[0]"

--- a/examples/Marks/Pyplot/HeatMap.ipynb
+++ b/examples/Marks/Pyplot/HeatMap.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scipy.misc import ascent\n",
+    "from scipy.datasets import ascent\n",
     "Z = ascent()\n",
     "Z = Z[::-1, :]\n",
     "aspect_ratio = Z.shape[1] / Z.shape[0]"

--- a/test-environment.yml
+++ b/test-environment.yml
@@ -23,3 +23,4 @@ dependencies:
     - flake8
     - nose
     - codespell
+    - pooch


### PR DESCRIPTION
According to https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.misc.ascent.html